### PR TITLE
Delegate more category-related responsibilities to categories.

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -1,7 +1,4 @@
 import CodeMirror from 'codemirror';
-import 'codemirror/mode/javascript/javascript';
-import 'codemirror/mode/css/css';
-import 'codemirror/mode/htmlmixed/htmlmixed';
 import PubSub from 'pubsub-js';
 import React from 'react';
 import {keypress} from 'keypress';

--- a/src/parsers/css/index.js
+++ b/src/parsers/css/index.js
@@ -1,2 +1,3 @@
 export const id = 'css';
 export const displayName = 'CSS';
+export const mimeTypes = ['text/css'];

--- a/src/parsers/css/index.js
+++ b/src/parsers/css/index.js
@@ -1,3 +1,5 @@
+import 'codemirror/mode/css/css';
+
 export const id = 'css';
 export const displayName = 'CSS';
 export const mimeTypes = ['text/css'];

--- a/src/parsers/html/index.js
+++ b/src/parsers/html/index.js
@@ -1,3 +1,5 @@
+import 'codemirror/mode/htmlmixed/htmlmixed';
+
 export const id = 'htmlmixed';
 export const displayName = 'HTML';
 export const mimeTypes = ['text/html'];

--- a/src/parsers/html/index.js
+++ b/src/parsers/html/index.js
@@ -1,2 +1,3 @@
 export const id = 'htmlmixed';
 export const displayName = 'HTML';
+export const mimeTypes = ['text/html'];

--- a/src/parsers/js/index.js
+++ b/src/parsers/js/index.js
@@ -1,2 +1,3 @@
 export const id = 'javascript';
 export const displayName = 'JavaScript';
+export const mimeTypes = ['text/javascript'];

--- a/src/parsers/js/index.js
+++ b/src/parsers/js/index.js
@@ -1,3 +1,5 @@
+import 'codemirror/mode/javascript/javascript';
+
 export const id = 'javascript';
 export const displayName = 'JavaScript';
 export const mimeTypes = ['text/javascript'];


### PR DESCRIPTION
This will allow category manifests to define their mime types without touching PasteDropTarget and import their CodeMirror modes without touching Editor.