### PR TITLE
Add AST -> transformed code highlighting with source maps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react": "^0.13.1",
     "recast": "^0.10.32",
     "shift-parser": "^3.0.4",
+    "source-map": "^0.5.3",
     "traceur": "0.0.93",
     "typescript": "^1.6.2",
     "uglify-js": "git+https://github.com/mishoo/UglifyJS2.git#harmony"

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -65,14 +65,7 @@ export default class Editor extends React.Component {
   }
 
   _posFromIndex(doc, index) {
-    let pos;
-    if (this.props.posFromIndex) {
-      pos = this.props.posFromIndex(index);
-    }
-    if (!pos) {
-      pos = doc.posFromIndex(index);
-    }
-    return pos;
+    return (this.props.posFromIndex ? this.props : doc).posFromIndex(index);
   }
 
   componentDidMount() {
@@ -120,9 +113,14 @@ export default class Editor extends React.Component {
           if (this._mark) {
             this._mark.clear();
           }
+          let [start, end] = range.map(index => this._posFromIndex(doc, index));
+          if (!start || !end) {
+            this._markerRange = this._mark = null;
+            return;
+          }
           this._mark = this.codeMirror.markText(
-            this._posFromIndex(doc, range[0]),
-            this._posFromIndex(doc, range[1]),
+            start,
+            end,
             {className: 'marked'}
           );
         }),

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -9,6 +9,9 @@ export default class Editor extends React.Component {
     highlight: React.PropTypes.bool,
     lineNumbers: React.PropTypes.bool,
     readOnly: React.PropTypes.bool,
+    onContentChange: React.PropTypes.func,
+    onActivity: React.PropTypes.func,
+    posFromIndex: React.PropTypes.func,
   }
 
   static defaultProps = {
@@ -61,6 +64,17 @@ export default class Editor extends React.Component {
     return false;
   }
 
+  _posFromIndex(doc, index) {
+    let pos;
+    if (this.props.posFromIndex) {
+      pos = this.props.posFromIndex(index);
+    }
+    if (!pos) {
+      pos = doc.posFromIndex(index);
+    }
+    return pos;
+  }
+
   componentDidMount() {
     this._CMHandlers = [];
     this._subscriptions = [];
@@ -107,8 +121,8 @@ export default class Editor extends React.Component {
             this._mark.clear();
           }
           this._mark = this.codeMirror.markText(
-            doc.posFromIndex(range[0]),
-            doc.posFromIndex(range[1]),
+            this._posFromIndex(doc, range[0]),
+            this._posFromIndex(doc, range[1]),
             {className: 'marked'}
           );
         }),

--- a/src/TransformOutput.js
+++ b/src/TransformOutput.js
@@ -98,7 +98,10 @@ export default class TransformOutput extends React.Component {
     if (!map) {
       return;
     }
-    let src = map.sourcesContent[0];
+    const src = map.sourcesContent[0];
+    if (pos === 0) {
+      return { line: 0, ch: 0 };
+    }
     let lineStart = src.lastIndexOf('\n', pos - 1);
     let column = pos - lineStart - 1;
     let line = 1;
@@ -111,6 +114,9 @@ export default class TransformOutput extends React.Component {
       column,
       source: map.sources[0],
     }));
+    if (line === null || column === null) {
+      return;
+    }
     return { line: line - 1, ch: column };
   }
 

--- a/src/TransformOutput.js
+++ b/src/TransformOutput.js
@@ -2,6 +2,7 @@
 import Editor from './Editor';
 import React from 'react';
 import halts, {loopProtect} from 'halting-problem';
+import {SourceMapConsumer} from 'source-map/lib/source-map-consumer';
 
 function transform(transformer, transformCode, code) {
   if (!transformer._promise) {
@@ -25,11 +26,17 @@ function transform(transformer, transformCode, code) {
         '})',
       ].join('')
     );
-    return transformer.transform(
+    let result = transformer.transform(
       realTransformer,
       transformCode,
       code,
     );
+    let map = null;
+    if (typeof result !== 'string') {
+      map = new SourceMapConsumer(result.map);
+      result = result.code;
+    }
+    return { result, map };
   });
 }
 
@@ -44,8 +51,10 @@ export default class TransformOutput extends React.Component {
     super(props);
     this.state = {
       result: '',
+      map: null,
       error: null,
     };
+    this._posFromIndex = this._posFromIndex.bind(this);
   }
 
   componentDidMount() {
@@ -54,8 +63,8 @@ export default class TransformOutput extends React.Component {
       this.props.transformCode,
       this.props.code,
     ).then(
-      result => this.setState({result}),
-      error => this.setState({error})
+      ({ result, map }) => this.setState({ result, map }),
+      error => this.setState({ error })
     );
   }
 
@@ -70,25 +79,39 @@ export default class TransformOutput extends React.Component {
         nextProps.transformCode,
         nextProps.code,
       ).then(
-        result => {
-          let error = null;
-          if (typeof result !== 'string') {
-            result = '';
-            error = new Error('Transform did not return a string.');
-          }
-          this.setState({result, error});
-        },
+        ({ result, map }) => ({ result, map, error: null }),
         error => {
           console.error(error);
-          this.setState({error});
+          return { error };
         }
-      );
+      ).then(state => this.setState(state));
     }
   }
 
   shouldComponentUpdate(nextProps, nextState) {
     return this.state.result !== nextState.result ||
       this.state.error !== nextState.error;
+  }
+
+  _posFromIndex(pos, doc) {
+    const {map} = this.state;
+    if (!map) {
+      return;
+    }
+    let src = map.sourcesContent[0];
+    let lineStart = src.lastIndexOf('\n', pos - 1);
+    let column = pos - lineStart - 1;
+    let line = 1;
+    while (lineStart >= 0) {
+      lineStart = src.lastIndexOf('\n', lineStart - 1);
+      line++;
+    }
+    ({ line, column } = map.generatedPositionFor({
+      line,
+      column,
+      source: map.sources[0],
+    }));
+    return { line: line - 1, ch: column };
   }
 
   render() {
@@ -103,7 +126,7 @@ export default class TransformOutput extends React.Component {
             defaultValue={this.state.error.message}
           /> :
           <Editor
-            highlight={false}
+            posFromIndex={this._posFromIndex}
             mode={this.props.mode}
             key="output"
             readOnly={true}

--- a/src/parsers/js/transformers/babel/index.js
+++ b/src/parsers/js/transformers/babel/index.js
@@ -27,6 +27,7 @@ export default {
     return babel.transform(code, {
       ...options,
       plugins: [transform],
-    }).code;
+      sourceMaps: true,
+    });
   },
 };

--- a/src/parsers/js/transformers/babel6/index.js
+++ b/src/parsers/js/transformers/babel6/index.js
@@ -28,6 +28,7 @@ export default {
     return babel.transform(code, {
       presets,
       plugins: [(transform.default || transform)(babel)],
-    }).code;
+      sourceMaps: true,
+    });
   },
 };


### PR DESCRIPTION
This enables ability to map AST to resulting code, so that chunks in both editors are now highlighted.

All that transformer needs to do is return pair `{ code, map }` instead of just `code` if it supports source maps.

Currently works for:
* `babel`
* `babelv6`
* `postcss`

![screenshot](https://cloud.githubusercontent.com/assets/557590/11725318/0c93ef82-9f71-11e5-9b21-75b1a0c5b52e.png)