### PR TITLE
Fix jscodeshift.registerMethods duplicates error across different runs.

### DIFF
--- a/src/parsers/js/transformers/jscodeshift/index.js
+++ b/src/parsers/js/transformers/jscodeshift/index.js
@@ -3,6 +3,8 @@ import pkg from 'jscodeshift/package.json';
 
 const ID = 'jscodeshift';
 
+const sessionMethods = new Set();
+
 export default {
   id: ID,
   displayName: ID,
@@ -13,11 +15,34 @@ export default {
 
   loadTransformer(callback) {
     require(['jscodeshift', 'babel-core'], (jscodeshift, babel) => {
+      const { registerMethods } = jscodeshift;
+
+      let origMethods;
+
+      jscodeshift.registerMethods({
+        hasOwnProperty(name) {
+          // compare only against current-session & very original methods
+          if (!origMethods) {
+            origMethods = new Set(Object.getOwnPropertyNames(this));
+          }
+          return origMethods.has(name) || sessionMethods.has(name);
+        },
+      });
+
+      // patch in order to collect user-defined method names
+      jscodeshift.registerMethods = function (methods) {
+        registerMethods.apply(this, arguments);
+        for (let name in methods) {
+          sessionMethods.add(name);
+        }
+      };
+
       callback({ jscodeshift, babel });
     });
   },
 
   transform({ jscodeshift, babel }, transformCode, code) {
+    sessionMethods.clear();
     let transform = compileModule( // eslint-disable-line no-shadow
       babel.transform(transformCode).code
     );


### PR DESCRIPTION
Added a hack to prevent errors on jscodeshift.registerMethods when editing, while still throwing on duplicates within same run.

Fixes #22.