### PR TITLE
Add ability to hide location data

### DIFF
--- a/src/components/ast/Element.js
+++ b/src/components/ast/Element.js
@@ -125,11 +125,12 @@ export default class Element extends React.Component {
   }
 
   _getProperties(parser, value) {
-    const {hideFunctions, hideEmptyKeys} = this.props.settings;
+    const {hideFunctions, hideEmptyKeys, hideLocationData} = this.props.settings;
     let properties = [...parser.forEachProperty(value)];
     return properties
       .filter(({value}) => !hideFunctions || typeof value !== 'function')
-      .filter(({value}) => !hideEmptyKeys || value != null);
+      .filter(({value}) => !hideEmptyKeys || value != null)
+      .filter(({key}) => !hideLocationData || parser.locationProps.indexOf(key) === -1);
   }
 
   _execFunction() {

--- a/src/components/ast/Element.js
+++ b/src/components/ast/Element.js
@@ -130,7 +130,7 @@ export default class Element extends React.Component {
     return properties
       .filter(({value}) => !hideFunctions || typeof value !== 'function')
       .filter(({value}) => !hideEmptyKeys || value != null)
-      .filter(({key}) => !hideLocationData || parser.locationProps.indexOf(key) === -1);
+      .filter(({key}) => !hideLocationData || !parser.locationProps.has(key));
   }
 
   _execFunction() {

--- a/src/components/visualization/Tree.js
+++ b/src/components/visualization/Tree.js
@@ -50,6 +50,14 @@ export default class Tree extends React.Component {
             />
             Hide empty keys
           </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={this.state.hideLocationData}
+              onChange={this._setOption.bind(this, 'hideLocationData')}
+            />
+          Hide location data
+          </label>
         </div>
         <ul onMouseLeave={() => {PubSub.publish('CLEAR_HIGHLIGHT');}}>
           <Element

--- a/src/parsers/css/cssom.js
+++ b/src/parsers/css/cssom.js
@@ -10,7 +10,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['__starts', '__ends'],
+  locationProps: new Set(['__starts', '__ends']),
 
   loadParser(callback) {
     require(['cssom/lib/parse'], callback);

--- a/src/parsers/css/cssom.js
+++ b/src/parsers/css/cssom.js
@@ -10,6 +10,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['__starts', '__ends'],
 
   loadParser(callback) {
     require(['cssom/lib/parse'], callback);

--- a/src/parsers/css/postcss.js
+++ b/src/parsers/css/postcss.js
@@ -20,7 +20,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['source'],
+  locationProps: new Set(['source']),
 
   loadParser(callback) {
     require(['postcss/lib/parse', 'postcss-scss/lib/scss-parse', 'postcss-safe-parser'], (builtIn, scss, safe) => {

--- a/src/parsers/css/postcss.js
+++ b/src/parsers/css/postcss.js
@@ -20,7 +20,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['start', 'end'],
+  locationProps: ['source'],
 
   loadParser(callback) {
     require(['postcss/lib/parse', 'postcss-scss/lib/scss-parse', 'postcss-safe-parser'], (builtIn, scss, safe) => {

--- a/src/parsers/css/postcss.js
+++ b/src/parsers/css/postcss.js
@@ -20,6 +20,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['start', 'end'],
 
   loadParser(callback) {
     require(['postcss/lib/parse', 'postcss-scss/lib/scss-parse', 'postcss-safe-parser'], (builtIn, scss, safe) => {

--- a/src/parsers/css/rework.js
+++ b/src/parsers/css/rework.js
@@ -10,7 +10,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['position'],
+  locationProps: new Set(['position']),
 
   loadParser(callback) {
     require(['css/lib/parse'], callback);

--- a/src/parsers/css/rework.js
+++ b/src/parsers/css/rework.js
@@ -10,6 +10,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['position'],
 
   loadParser(callback) {
     require(['css/lib/parse'], callback);

--- a/src/parsers/graphql/graphql-js.js
+++ b/src/parsers/graphql/graphql-js.js
@@ -19,6 +19,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['loc'],
 
   loadParser(callback) {
     require(['graphql/language'], ({ parse }) => {

--- a/src/parsers/graphql/graphql-js.js
+++ b/src/parsers/graphql/graphql-js.js
@@ -19,7 +19,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['loc'],
+  locationProps: new Set(['loc']),
 
   loadParser(callback) {
     require(['graphql/language'], ({ parse }) => {

--- a/src/parsers/html/htmlparser2.js
+++ b/src/parsers/html/htmlparser2.js
@@ -20,7 +20,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['startIndex'],
+  locationProps: new Set(['startIndex']),
 
   loadParser(callback) {
     require(['htmlparser2/lib/Parser', 'domhandler'], (Parser, DomHandler) => {

--- a/src/parsers/html/htmlparser2.js
+++ b/src/parsers/html/htmlparser2.js
@@ -20,6 +20,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['startIndex'],
 
   loadParser(callback) {
     require(['htmlparser2/lib/Parser', 'domhandler'], (Parser, DomHandler) => {

--- a/src/parsers/html/parse5.js
+++ b/src/parsers/html/parse5.js
@@ -20,7 +20,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['__location'],
+  locationProps: new Set(['__location']),
 
   loadParser(callback) {
     require([

--- a/src/parsers/html/parse5.js
+++ b/src/parsers/html/parse5.js
@@ -20,6 +20,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['__location'],
 
   loadParser(callback) {
     require([

--- a/src/parsers/js/acorn.js
+++ b/src/parsers/js/acorn.js
@@ -21,7 +21,7 @@ export default {
   displayName: ID,
   version: `${pkg.version} (acorn-jsx: ${jsxPkg.version})`,
   homepage: pkg.homepage,
-  locationProps: ['range'],
+  locationProps: new Set(['range']),
 
   loadParser(callback) {
     require(['acorn', 'acorn-jsx/inject'], (acorn, jsxInject) => {

--- a/src/parsers/js/acorn.js
+++ b/src/parsers/js/acorn.js
@@ -21,6 +21,7 @@ export default {
   displayName: ID,
   version: `${pkg.version} (acorn-jsx: ${jsxPkg.version})`,
   homepage: pkg.homepage,
+  locationProps: ['range'],
 
   loadParser(callback) {
     require(['acorn', 'acorn-jsx/inject'], (acorn, jsxInject) => {

--- a/src/parsers/js/babel-eslint.js
+++ b/src/parsers/js/babel-eslint.js
@@ -11,7 +11,7 @@ export default {
   displayName: name,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['loc', 'start', 'end'],
+  locationProps: new Set(['loc', 'start', 'end']),
 
   loadParser(callback) {
     require(['acorn-to-esprima', 'babel-core'], (acornToEsprima, {acorn: {tokTypes}, traverse, parse}) => {

--- a/src/parsers/js/babel-eslint.js
+++ b/src/parsers/js/babel-eslint.js
@@ -11,6 +11,7 @@ export default {
   displayName: name,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['loc', 'start', 'end'],
 
   loadParser(callback) {
     require(['acorn-to-esprima', 'babel-core'], (acornToEsprima, {acorn: {tokTypes}, traverse, parse}) => {

--- a/src/parsers/js/babylon.js
+++ b/src/parsers/js/babylon.js
@@ -31,6 +31,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['loc', 'start', 'end'],
 
   loadParser(callback) {
     require(['babylon'], callback);

--- a/src/parsers/js/babylon.js
+++ b/src/parsers/js/babylon.js
@@ -31,7 +31,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['loc', 'start', 'end'],
+  locationProps: new Set(['loc', 'start', 'end']),
 
   loadParser(callback) {
     require(['babylon'], callback);

--- a/src/parsers/js/babylon6.js
+++ b/src/parsers/js/babylon6.js
@@ -36,7 +36,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['loc', 'start', 'end'],
+  locationProps: new Set(['loc', 'start', 'end']),
 
   loadParser(callback) {
     require(['babylon6'], callback);

--- a/src/parsers/js/babylon6.js
+++ b/src/parsers/js/babylon6.js
@@ -36,6 +36,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['loc', 'start', 'end'],
 
   loadParser(callback) {
     require(['babylon6'], callback);

--- a/src/parsers/js/espree.js
+++ b/src/parsers/js/espree.js
@@ -51,7 +51,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['range'],
+  locationProps: new Set(['range']),
 
   loadParser(callback) {
     require(['espree'], callback);

--- a/src/parsers/js/espree.js
+++ b/src/parsers/js/espree.js
@@ -51,6 +51,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['range'],
 
   loadParser(callback) {
     require(['espree'], callback);

--- a/src/parsers/js/esprima.js
+++ b/src/parsers/js/esprima.js
@@ -33,6 +33,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['range'],
 
   loadParser(callback) {
     require(['esprima'], callback);

--- a/src/parsers/js/esprima.js
+++ b/src/parsers/js/esprima.js
@@ -33,7 +33,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['range'],
+  locationProps: new Set(['range']),
 
   loadParser(callback) {
     require(['esprima'], callback);

--- a/src/parsers/js/recast.js
+++ b/src/parsers/js/recast.js
@@ -25,6 +25,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['range', 'loc'],
 
   loadParser(callback) {
     require(['recast', 'esprima', 'babel-core'], (recast, esprima, babelCore) => {

--- a/src/parsers/js/recast.js
+++ b/src/parsers/js/recast.js
@@ -25,7 +25,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['range', 'loc'],
+  locationProps: new Set(['range', 'loc']),
 
   loadParser(callback) {
     require(['recast', 'esprima', 'babel-core'], (recast, esprima, babelCore) => {

--- a/src/parsers/js/shift.js
+++ b/src/parsers/js/shift.js
@@ -24,7 +24,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['loc'],
+  locationProps: new Set(['loc']),
 
   loadParser(callback) {
     require(['shift-parser'], callback);

--- a/src/parsers/js/shift.js
+++ b/src/parsers/js/shift.js
@@ -24,6 +24,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['loc'],
 
   loadParser(callback) {
     require(['shift-parser'], callback);

--- a/src/parsers/js/traceur.js
+++ b/src/parsers/js/traceur.js
@@ -68,6 +68,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['location'],
 
   loadParser(callback) {
     require(['exports?traceur!traceur/bin/traceur'], callback);

--- a/src/parsers/js/traceur.js
+++ b/src/parsers/js/traceur.js
@@ -68,7 +68,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['location'],
+  locationProps: new Set(['location']),
 
   loadParser(callback) {
     require(['exports?traceur!traceur/bin/traceur'], callback);

--- a/src/parsers/js/typescript.js
+++ b/src/parsers/js/typescript.js
@@ -33,6 +33,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['pos', 'end'],
 
   loadParser(callback) {
     require(['typescript'], _ts => callback(ts = _ts));

--- a/src/parsers/js/typescript.js
+++ b/src/parsers/js/typescript.js
@@ -33,7 +33,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['pos', 'end'],
+  locationProps: new Set(['pos', 'end']),
 
   loadParser(callback) {
     require(['typescript'], _ts => callback(ts = _ts));

--- a/src/parsers/js/uglify.js
+++ b/src/parsers/js/uglify.js
@@ -11,7 +11,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
-  locationProps: ['start', 'end'],
+  locationProps: new Set(['start', 'end']),
 
   loadParser(callback) {
     require([

--- a/src/parsers/js/uglify.js
+++ b/src/parsers/js/uglify.js
@@ -11,6 +11,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage,
+  locationProps: ['start', 'end'],
 
   loadParser(callback) {
     require([

--- a/src/parsers/utils/defaultParserInterface.js
+++ b/src/parsers/utils/defaultParserInterface.js
@@ -1,6 +1,6 @@
 export default {
   _ignoredProperties: new Set(),
-  locationProps: [],
+  locationProps: new Set(),
 
   opensByDefault(/*node, key*/) {
     return false;

--- a/src/parsers/utils/defaultParserInterface.js
+++ b/src/parsers/utils/defaultParserInterface.js
@@ -1,5 +1,6 @@
 export default {
   _ignoredProperties: new Set(),
+  locationProps: [],
 
   opensByDefault(/*node, key*/) {
     return false;


### PR DESCRIPTION
Added the ability to hide the node's location data in order to remove clutter when interrogating the structure and data of the node.
Location property names are configurable per parser. 