### PR TITLE
Add flow-parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The AST explorer provides following code parsers:
   - [traceur][]
   - [typescript][]
   - [uglify-js][]
+  - [flow-parser][]
 - CSS:
   - [cssom][]
   - [postcss][] + [postcss-safe-parser][] & [postcss-scss][]
@@ -83,6 +84,7 @@ node.
 [rework]: https://github.com/reworkcss/rework
 [htmlparser2]: https://github.com/fb55/htmlparser2
 [parse5]: https://github.com/inikulin/parse5
+[flow-parser]: https://github.com/facebook/flow/tree/master/src/parser
 
 ### Contributions
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "escodegen": "^1.4.1",
     "espree": "^2.2.4",
     "esprima": "^2.5",
+    "flow-parser": "^0.7.0",
     "font-awesome": "^4.5.0",
     "graphql": "^0.4.14",
     "halting-problem": "^1.0.2",

--- a/src/parsers/js/flow.js
+++ b/src/parsers/js/flow.js
@@ -1,0 +1,64 @@
+import React from 'react'; // eslint-disable-line no-unused-vars
+import defaultParserInterface from './utils/defaultESTreeParserInterface';
+import pkg from 'flow-parser/package.json';
+import SettingsRenderer from '../utils/SettingsRenderer';
+import * as LocalStorage from '../../LocalStorage';
+
+const ID = 'flow';
+const options = {
+	// TODO: We need to update the flow-parser package to the latest build of Flow
+	//       before these settings actually do anything.
+	/*
+	esproposal_decorators: true,
+	esproposal_class_instance_fields: true,
+	esproposal_class_static_fields: true,
+	types: true,
+	*/
+  ...LocalStorage.getParserSettings(ID),
+};
+
+const settings = [
+	// TODO: We need to update the flow-parser package to the latest build of Flow
+	//       before these settings actually do anything.
+	/*
+	'esproposal_decorators',
+	'esproposal_class_instance_fields',
+	'esproposal_class_static_fields',
+	'types',
+	*/
+];
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: ID,
+  version: pkg.version,
+  homepage: pkg.homepage,
+  locationProps: new Set(['range', 'loc']),
+
+  loadParser(callback) {
+    require(['flow-parser'], callback);
+  },
+
+  parse(flowParser, code) {
+		return flowParser.parse(code);
+  },
+
+	// TODO: We need to update the flow-parser package to the latest build of Flow
+	//       before these settings actually do anything.
+	/*
+  renderSettings() {
+    return SettingsRenderer({
+      settings,
+      values: options,
+      onChange: changeOption,
+    });
+  },
+	*/
+};
+
+function changeOption(name, {target: {value}}) {
+  options[name] = value;
+  LocalStorage.setParserSettings(ID, options);
+}


### PR DESCRIPTION
`flow-parser` is a compiled-to-JS version of the OCaml Flow parser. It's mildly out of date right now, but I'll follow up with a version bump once we ship Flow 0.21 in the next few weeks.

Tested this by building locally, loading up, trying out the new parser. Settings tab is grayed out for now -- parsing works.