### PR TITLE
Fix bug changing Babylon sourceType

### DIFF
--- a/src/parsers/js/babylon.js
+++ b/src/parsers/js/babylon.js
@@ -76,7 +76,7 @@ let plugins = ['jsx', 'flow'];
 
 function changeOption(name, {target}) {
   if (name === 'sourceType') {
-    options.sourceType = target.vaue;
+    options.sourceType = target.value;
   } else if(parserSettings.indexOf(name) > -1) {
     options[name] = target.checked;
   } else if (features.indexOf(name) > -1) {


### PR DESCRIPTION
The `changeOption` handler was attempting to read from `target.vaue` instead of `target.value`. Previously, changing `sourceType` from "module" (the default) to "script" would cause the parser to warn about module-specific code, but reopening settings would show that `sourceType` was still "module".