### PR TITLE
Fix Espree comment option

### DIFF
--- a/src/parsers/js/espree.js
+++ b/src/parsers/js/espree.js
@@ -8,7 +8,7 @@ const ID = 'espree';
 const options = {
   range: true,
   loc: false,
-  comments: false,
+  comment: false,
   attachComment: false,
   tokens: false,
   tolerant: true,


### PR DESCRIPTION
Previously, the Espree docs had the option as `comments`, though the correct name is `comment`. The Espree documentation was corrected in eslint/espree#248.