### PR TITLE
Fix Espree ecmaVersion setting

### DIFF
--- a/src/parsers/js/espree.js
+++ b/src/parsers/js/espree.js
@@ -57,6 +57,8 @@ function changeOption(name, {target}) {
   if (parserSettings.indexOf(name) > -1) {
     switch (name) {
       case 'ecmaVersion':
+        options[name] = +target.value;
+        break;
       case 'sourceType':
         options[name] = target.value;
         break;


### PR DESCRIPTION
Previously, `ecmaVersion` was being set as a string, but Espree expects a number. This change ensures that `ecmaVersion` is always set as a number.