### PR TITLE
Upgrade Acorn and Espree for ES7 support

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "1.9.0",
   "dependencies": {
     "acorn": {
-      "version": "3.0.2",
-      "from": "acorn@3.0.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.0.2.tgz"
+      "version": "3.0.4",
+      "from": "acorn@latest",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.0.4.tgz"
     },
     "acorn-jsx": {
       "version": "2.0.1",
@@ -549,7 +549,8 @@
         },
         "babel-types": {
           "version": "6.5.2",
-          "from": "babel-types@>=6.5.2 <7.0.0"
+          "from": "babel-types@6.5.2",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.5.2.tgz"
         },
         "babylon": {
           "version": "6.5.2",
@@ -1076,7 +1077,8 @@
       "dependencies": {
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
-          "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0"
+          "from": "esprima-fb@15001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
         }
       }
     },
@@ -1284,16 +1286,9 @@
       }
     },
     "espree": {
-      "version": "3.0.2",
-      "from": "espree@3.0.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.0.2.tgz",
-      "dependencies": {
-        "acorn": {
-          "version": "2.7.0",
-          "from": "acorn@>=2.7.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
-        }
-      }
+      "version": "3.1.0",
+      "from": "espree@latest",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.0.tgz"
     },
     "esprima": {
       "version": "2.7.2",
@@ -2486,7 +2481,8 @@
     },
     "jscodeshift": {
       "version": "0.3.13",
-      "from": "jscodeshift@0.3.13"
+      "from": "jscodeshift@0.3.13",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.3.13.tgz"
     },
     "jsesc": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "webpack": "^1.12.8"
   },
   "dependencies": {
-    "acorn": "^3.0.0",
+    "acorn": "^3.0.4",
     "acorn-jsx": "^2.0.1",
     "acorn-to-esprima": "^1.0.2",
     "babel-core": "^5.7.3",
@@ -49,7 +49,7 @@
     "cssom": "^0.3.0",
     "domhandler": "^2.3.0",
     "escodegen": "^1.4.1",
-    "espree": "^3.0.1",
+    "espree": "^3.1.0",
     "esprima": "^2.5",
     "flow-parser": "^0.21.0",
     "font-awesome": "^4.5.0",

--- a/src/parsers/js/acorn.js
+++ b/src/parsers/js/acorn.js
@@ -49,7 +49,7 @@ export default {
 };
 
 const settings = [
-  ['ecmaVersion', [3, 5, 6]],
+  ['ecmaVersion', [3, 5, 6, 7]],
   ['sourceType', ['script', 'module']],
   'allowReserved',
   'allowReturnOutsideFunction',

--- a/src/parsers/js/espree.js
+++ b/src/parsers/js/espree.js
@@ -47,7 +47,7 @@ export default {
 };
 
 let parserSettings = [
-  ['ecmaVersion', [3, 5, 6]],
+  ['ecmaVersion', [3, 5, 6, 7]],
   ['sourceType', ['script', 'module']],
   ...Object.keys(options).filter(v => v !== 'ecmaFeatures'),
 ];


### PR DESCRIPTION
Acorn 3.0.0 added support for `ecmaVersion: 7` and the exponentiation operator. Upgrading to 3.0.4 fixes a bug with the exponentiation operator.

Espree 3.1.0 adds support for `ecmaVersion: 7` and the exponentiation operator.

--

I tried doing this without altering `npm-shrinkwrap.json`, but that didn't work. If you'd like me to `git checkout master -- npm-shrinkwrap.json` to remove it from this PR so you can handle those changes yourself, I'm happy to do that.