### PR TITLE
Add proper Web IDL highlighting

### DIFF
--- a/src/CategoryButton.js
+++ b/src/CategoryButton.js
@@ -6,7 +6,7 @@ const categoryIcon = {
   javascript: 'fa-jsfiddle',
   css: 'fa-css3',
   htmlmixed: 'fa-html5',
-  idl: 'fa-th-list',
+  webidl: 'fa-th-list',
 };
 
 export default class CategoryButton extends React.Component {

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -12,6 +12,7 @@ const restrictedParserNames = new Set([
   'index.js',
   'codeExample.txt',
   'transformers',
+  'utils',
 ]);
 
 export const categories =

--- a/src/parsers/webidl/index.js
+++ b/src/parsers/webidl/index.js
@@ -1,5 +1,9 @@
-import 'codemirror/mode/idl/idl';
+// Until Web IDL mode has been officially merged into CodeMirror, use the
+// local version of the mode.
 
-export const id = 'idl';
-export const displayName = 'WebIDL';
-export const mimeTypes = ['text/x-idl'];
+// import 'codemirror/mode/webidl/webidl';
+import './utils/mode';
+
+export const id = 'webidl';
+export const displayName = 'Web IDL';
+export const mimeTypes = ['text/x-webidl'];

--- a/src/parsers/webidl/utils/mode.js
+++ b/src/parsers/webidl/utils/mode.js
@@ -1,0 +1,191 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+// (function(mod) {
+//   if (typeof exports == "object" && typeof module == "object") // CommonJS
+//     mod(require("../../lib/codemirror"));
+//   else if (typeof define == "function" && define.amd) // AMD
+//     define(["../../lib/codemirror"], mod);
+//   else // Plain browser env
+//     mod(CodeMirror);
+// })(function(CodeMirror) {
+"use strict";
+
+import * as CodeMirror from "codemirror/lib/codemirror";
+
+function wordRegexp(words) {
+  return new RegExp("^((" + words.join(")|(") + "))\\b");
+};
+
+var builtinArray = [
+  "Clamp",
+  "Constructor",
+  "EnforceRange",
+  "Exposed",
+  "ImplicitThis",
+  "Global", "PrimaryGlobal",
+  "LegacyArrayClass",
+  "LegacyUnenumerableNamedProperties",
+  "LenientThis",
+  "NamedConstructor",
+  "NewObject",
+  "NoInterfaceObject",
+  "OverrideBuiltins",
+  "PutForwards",
+  "Replaceable",
+  "SameObject",
+  "TreatNonObjectAsNull",
+  "TreatNullAs",
+    "EmptyString",
+  "Unforgeable",
+  "Unscopeable"
+];
+var builtins = wordRegexp(builtinArray);
+
+var typeArray = [
+  "unsigned", "short", "long",                  // UnsignedIntegerType
+  "unrestricted", "float", "double",            // UnrestrictedFloatType
+  "boolean", "byte", "octet",                   // Rest of PrimitiveType
+  "Promise",                                    // PromiseType
+  "ArrayBuffer", "DataView", "Int8Array", "Int16Array", "Int32Array",
+  "Uint8Array", "Uint16Array", "Uint32Array", "Uint8ClampedArray",
+  "Float32Array", "Float64Array",               // BufferRelatedType
+  "ByteString", "DOMString", "USVString", "sequence", "object", "RegExp",
+  "Error", "DOMException", "FrozenArray",       // Rest of NonAnyType
+  "any",                                        // Rest of SingleType
+  "void"                                        // Rest of ReturnType
+];
+var types = wordRegexp(typeArray);
+
+var keywordArray = [
+  "attribute", "callback", "const", "deleter", "dictionary", "enum", "getter",
+  "implements", "inherit", "interface", "iterable", "legacycaller", "maplike",
+  "partial", "required", "serializer", "setlike", "setter", "static",
+  "stringifier", "typedef",                     // ArgumentNameKeyword except
+                                                // "unrestricted"
+  "optional", "readonly", "or"
+];
+var keywords = wordRegexp(keywordArray);
+
+var atomArray = [
+  "true", "false",                              // BooleanLiteral
+  "Infinity", "NaN",                            // FloatLiteral
+  "null"                                        // Rest of ConstValue
+];
+var atoms = wordRegexp(atomArray);
+
+CodeMirror.registerHelper("hintWords", "webidl",
+    builtinArray.concat(typeArray).concat(keywordArray).concat(atomArray));
+
+var startDefArray = ["callback", "dictionary", "enum", "interface"];
+var startDefs = wordRegexp(startDefArray);
+
+var endDefArray = ["typedef"];
+var endDefs = wordRegexp(endDefArray);
+
+var singleOperators = /^[:<=>?]/;
+var integers = /^-?([1-9][0-9]*|0[Xx][0-9A-Fa-f]+|0[0-7]*)/;
+var floats = /^-?(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][+-]?[0-9]+)?|[0-9]+[Ee][+-]?[0-9]+)/;
+var identifiers = /^_?[A-Za-z][0-9A-Z_a-z-]*/;
+var strings = /^"[^"]*"/;
+var multilineComments = /^\/\*(.|\n)*?\*\//;
+
+function skipSpaceAndMatch(stream, regexp) {
+  var pos = stream.pos;
+  stream.eatSpace();
+  var match = stream.match(regexp, false);
+  stream.pos = pos;
+  return match || [];
+}
+
+function readToken(stream, state) {
+  // whitespace
+  if (stream.eatSpace()) return null;
+
+  // comment
+  if (stream.match("//")) {
+    stream.skipToEnd();
+    return "comment";
+  }
+  if (stream.match(multilineComments)) return "comment";
+
+  // integer and float
+  if (stream.match(/^-?[0-9\.]/, false)) {
+    if (stream.match(integers) || stream.match(floats)) return "number";
+  }
+
+  // string
+  if (stream.match(strings)) return "string";
+
+  // identifier
+  var pos = stream.pos;
+  if (stream.match(identifiers)) {
+    if (state.startDef) return "def";
+    if (state.endDef && skipSpaceAndMatch(stream, /./)[0] == ";") {
+      state.endDef = false;
+      return "def";
+    }
+    stream.pos = pos;
+  }
+
+  if (stream.match(keywords)) return "keyword";
+
+  if (stream.match(types)) {
+    var lastToken = state.lastToken;
+    var nextToken = skipSpaceAndMatch(stream, /.+?\b/)[0];
+
+    if (lastToken === ":" || lastToken === "implements" ||
+        nextToken === "implements" || nextToken === "=") {
+      // Used as identifier
+      return "builtin";
+    } else {
+      // Used as type
+      return "variable-3";
+    }
+  }
+
+  if (stream.match(builtins)) return "builtin";
+  if (stream.match(atoms)) return "atom";
+  if (stream.match(identifiers)) return "variable";
+
+  // other
+  if (stream.match(singleOperators)) return "operator";
+
+  // unrecognized
+  stream.next();
+  return null;
+};
+
+CodeMirror.defineMode("webidl", function() {
+  return {
+    startState: function() {
+      return {
+        // Last non-whitespace, matched token
+        lastToken: "",
+        // Next token is a definition
+        startDef: false,
+        // Last token of the statement is a definition
+        endDef: false
+      };
+    },
+    token: function(stream, state) {
+      var style = readToken(stream, state);
+
+      if (style) {
+        var cur = stream.current();
+        state.lastToken = cur;
+        if (style === "keyword") {
+          state.startDef = startDefs.test(cur);
+          state.endDef = state.endDef || endDefs.test(cur);
+        } else {
+          state.startDef = false;
+        }
+      }
+
+      return style;
+    }
+  };
+});
+
+CodeMirror.defineMIME("text/x-webidl", "webidl");
+// });


### PR DESCRIPTION
Before the CodeMirror IDL mode was used, which was not for Interface Definition Language but rather for the unrelated Interactive Data Language.

The Web IDL mode for CodeMirror, included in this PR, is adapted from the mode submitted to CM as codemirror/CodeMirror#3933.

![screenshot from 2016-04-02 21 09 24](https://cloud.githubusercontent.com/assets/1538624/14230707/3dbf266c-f917-11e5-81de-eeccc07051db.png)
