### PR TITLE
Update Flow parser to v0.23.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ as possible!
 #### Build your own version
 
 Install all dependencies with `npm install`.
+Make sure submodules are updated with `git submodule update --init`.
 
 Run `npm run build` for the final minimized version.
 Run `npm run watch` for incremental builds.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint2": "file:packages/eslint2",
     "espree": "^3.1.0",
     "esprima": "^2.5",
-    "flow-parser": "^0.21.0",
+    "flow-parser": "^0.23.1",
     "font-awesome": "^4.5.0",
     "graphql": "^0.4.14",
     "halting-problem": "^1.0.2",

--- a/src/parsers/js/flow.js
+++ b/src/parsers/js/flow.js
@@ -6,17 +6,19 @@ import * as LocalStorage from '../../LocalStorage';
 
 const ID = 'flow';
 const options = {
-  esproposal_decorators: true,
   esproposal_class_instance_fields: true,
   esproposal_class_static_fields: true,
+  esproposal_decorators: true,
+  esproposal_export_star_as: true,
   types: true,
   ...LocalStorage.getParserSettings(ID),
 };
 
 const settings = [
-  'esproposal_decorators',
   'esproposal_class_instance_fields',
   'esproposal_class_static_fields',
+  'esproposal_decorators',
+  'esproposal_export_star_as',
   'types',
 ];
 


### PR DESCRIPTION
Updates:

* `esproposal_export_star_as` option
* parse error on duplicate export names
* support for leading `|` and `&` in unions
* fixes for default values in destructuring declarations
* allow trailing commas in type parameter lists
* fix parsing of `export default function<T>() {}`
* type parameters now specify variance `+`/`-`
* fix bug when parsing `async` class properties
* support for toplevel class-decorators now under the `esproposal_decorators` option