### PR TITLE
Allow `transform` of Transformers to return promise

### DIFF
--- a/src/TransformOutput.js
+++ b/src/TransformOutput.js
@@ -31,12 +31,14 @@ function transform(transformer, transformCode, code) {
       transformCode,
       code,
     );
-    let map = null;
-    if (typeof result !== 'string') {
-      map = new SourceMapConsumer(result.map);
-      result = result.code;
-    }
-    return { result, map };
+    return Promise.resolve(result).then(result => {
+      let map = null;
+      if (typeof result !== 'string') {
+        map = new SourceMapConsumer(result.map);
+        result = result.code;
+      }
+      return { result, map };
+    });
   });
 }
 


### PR DESCRIPTION
It allow Transformer#transform to work as async.

I think that it is needed to implemenet async tranform like [stylelint](http://stylelint.io/ "stylelint") #118 and [textlint](https://textlint.github.io/ "textlint").
These tools has only async linting(transform) function.

- https://github.com/textlint/textlint/blob/master/docs/use-as-modules.md#core `textlint.lintText()` return `Promise<TextLintResult>`
- http://stylelint.io/user-guide/node-api/ `stylelint.lint()` reutn `Promise`.

P.S. I work on adding [textlint](https://textlint.github.io/ "textlint") to astexplorer which will be fork version. https://github.com/azu/astexplorer/pull/1
Async transform was needed to support textlint's transform. 