### PR TITLE
Add babel6 syntax preset.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -593,6 +593,11 @@
       "from": "babel-preset-stage-3@>=6.3.13 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.5.0.tgz"
     },
+    "babel-preset-syntax-from-presets": {
+      "version": "1.0.0",
+      "from": "babel-preset-syntax-from-presets@latest",
+      "resolved": "https://registry.npmjs.org/babel-preset-syntax-from-presets/-/babel-preset-syntax-from-presets-1.0.0.tgz"
+    },
     "babel-register": {
       "version": "6.7.2",
       "from": "babel-register@>=6.7.2 <7.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-0": "^6.1.18",
+    "babel-preset-syntax-from-presets": "^1.0.0",
     "babel-runtime": "^5.8.19",
     "babel6": "file:packages/babel6",
     "babylon": "^5.8.22",

--- a/src/parsers/js/transformers/babel6/index.js
+++ b/src/parsers/js/transformers/babel6/index.js
@@ -14,19 +14,20 @@ export default {
   loadTransformer(callback) {
     require([
       'babel6',
+      'babel-preset-syntax-from-presets',
       'babel-preset-es2015',
       'babel-preset-stage-0',
       'babel-preset-react',
-    ], (babel, ...presets) => callback({ babel, presets }));
+    ], (babel, syntaxPreset, ...presets) => callback({ babel, syntaxPreset, presets }));
   },
 
-  transform({ babel, presets }, transformCode, code) {
+  transform({ babel, syntaxPreset, presets }, transformCode, code) {
     let transform = compileModule( // eslint-disable-line no-shadow
       babel.transform(transformCode, { presets }).code
     );
 
     return babel.transform(code, {
-      presets: [],
+      presets: [syntaxPreset],
       plugins: [(transform.default || transform)(babel)],
       sourceMaps: true,
     });


### PR DESCRIPTION
Fixes syntax errors in babel6 caused by #112. Doesn't fix #120, but fixes the reason I created #120.