### PR TITLE
Remove `parent` property from TypeScript AST

### DIFF
--- a/src/parsers/js/typescript.js
+++ b/src/parsers/js/typescript.js
@@ -101,7 +101,8 @@ export default {
     for (let prop in node) {
       if (
         prop === 'constructor' ||
-        prop.charAt(0) === '_'
+        prop.charAt(0) === '_' ||
+        prop === 'parent'
       ) {
         continue;
       }


### PR DESCRIPTION
The `parent` property causes many AST elements to highlight rather than the selected element. Since the information is already visualized as a tree, the `parent` property provides no additional information.