### PR TITLE
Update default parser for JSCodeShift transform

### DIFF
--- a/src/parsers/js/transformers/jscodeshift/index.js
+++ b/src/parsers/js/transformers/jscodeshift/index.js
@@ -11,7 +11,7 @@ export default {
   version: pkg.version,
   homepage: pkg.homepage,
 
-  defaultParserID: 'recast',
+  defaultParserID: 'babylon6',
 
   loadTransformer(callback) {
     require(['jscodeshift', 'babel-core'], (jscodeshift, babel) => {


### PR DESCRIPTION
I believe this matches [the current parser used by JSCodeShift](https://github.com/facebook/jscodeshift/issues/14)