### PR TITLE
Add postcss-less as one of the PostCSS parsers

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4352,6 +4352,11 @@
       "from": "postcss-filter-plugins@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz"
     },
+    "postcss-less": {
+      "version": "0.12.0",
+      "from": "postcss-less@latest",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-0.12.0.tgz"
+    },
     "postcss-merge-idents": {
       "version": "2.1.6",
       "from": "postcss-merge-idents@>=2.1.5 <3.0.0",
@@ -4676,7 +4681,7 @@
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
           "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+          "resolved": "http://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
         },
         "recast": {
           "version": "0.10.33",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "parse": "^1.6.9",
     "parse5": "^2.0.0",
     "postcss": "^5.0.12",
+    "postcss-less": "^0.12.0",
     "postcss-safe-parser": "^1.0.1",
     "postcss-scss": "^0.1.3",
     "pubsub-js": "^1.4.2",

--- a/src/parsers/css/postcss.js
+++ b/src/parsers/css/postcss.js
@@ -10,7 +10,7 @@ const defaultOptions = {
 
 const parserSettingsConfiguration = {
   fields: [
-    ['parser', ['built-in', 'scss', 'safe-parser']],
+    ['parser', ['built-in', 'scss', 'less', 'safe-parser']],
   ],
 };
 
@@ -24,10 +24,11 @@ export default {
   locationProps: new Set(['source']),
 
   loadParser(callback) {
-    require(['postcss/lib/parse', 'postcss-scss/lib/scss-parse', 'postcss-safe-parser'], (builtIn, scss, safe) => {
+    require(['postcss/lib/parse', 'postcss-scss/lib/scss-parse', 'postcss-less/dist/less-parse', 'postcss-safe-parser'], (builtIn, scss, less, safe) => {
       callback({
         'built-in': builtIn,
         scss,
+        less,
         'safe-parser': safe,
       });
     });


### PR DESCRIPTION
I've added `postcss-less` PostCSS parser from https://github.com/webschik/postcss-less. Everything seems straightforward to add a new plugin in PostCSS and I've tested the output of the tree but I might have missed a few things or two. Please let me know if so.