### PR TITLE
gitignore packages/*/node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /out
-/node_modules
+node_modules


### PR DESCRIPTION
Is it just me or should we be ignoring node_modules in `packages/`? for example https://github.com/fkling/astexplorer/tree/master/packages/babel6