### PR TITLE
Bump flow-parser to v0.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint2": "file:packages/eslint2",
     "espree": "^3.1.0",
     "esprima": "^2.5",
-    "flow-parser": "^0.23.1",
+    "flow-parser": "^0.28.0",
     "font-awesome": "^4.5.0",
     "graphql": "^0.4.14",
     "halting-problem": "^1.0.2",


### PR DESCRIPTION
Updates:

* Support for defaults in type parameter declarations (i.e. `type T<A=number> = ...`)
* Support for `declare module.exports`
* Support for exponentiation operator (`**`)
* Fixed parsing of `/x/* 5 */y/` - that's no comment!
* Fixed parsing of newlines or comments at the end of a template literal.
* Support for `declare export` within `declare module {}` bodies