### PR TITLE
add esformatter to parsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cssom": "^0.3.0",
     "domhandler": "^2.3.0",
     "escodegen": "^1.4.1",
+    "esformatter-parser": "^1.0.0",
     "eslint1": "file:packages/eslint1",
     "eslint2": "file:packages/eslint2",
     "espree": "^3.1.0",

--- a/src/parsers/js/esformatter.js
+++ b/src/parsers/js/esformatter.js
@@ -1,0 +1,60 @@
+import defaultParserInterface from './utils/defaultESTreeParserInterface';
+import pkg from 'esformatter-parser/package.json';
+
+const ID = 'esformatter-parser';
+const name = 'esformatter';
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: name,
+  version: pkg.version,
+  homepage: pkg.homepage,
+  locationProps: new Set(['loc', 'start', 'end', 'range']),
+
+  loadParser(callback) {
+    require(['esformatter-parser'], (parser) => {
+      callback(parser);
+    });
+  },
+
+  parse(parser, code) {
+    return parser.parse(code);
+  },
+
+  *forEachProperty(node) {
+    for (let prop in node) {
+      if (this._ignoredProperties.has(prop)) {
+        continue;
+      }
+
+      let value = node[prop];
+
+      if (node.type !== 'Program' && prop === 'parent') {
+        value = '[Circular]';
+      }
+
+      yield {
+        value,
+        key: prop,
+        computed: false,
+      }
+    }
+  },
+
+  _ignoredProperties: new Set([
+    '_paths',
+    '_babelType',
+    '__clone',
+    // hide some extra properties to reduce noise
+    'comments',
+    'directives',
+    'extra',
+    'leadingComments',
+    'root',
+    'sourceType',
+    'tokens',
+    'trailingComments',
+  ]),
+};


### PR DESCRIPTION
The AST used by [esformatter](https://github.com/millermedeiros/esformatter) is very similar to `babel-eslint`, but we also have a linked list of tokens (which can be accessed through the `startToken`/`endToken` props); Nodes that are inside Arrays, also have `next` and `prev` properties (see [rocambole](https://github.com/millermedeiros/rocambole) for more details). Given these differences, I believe it's worth the addition.

This will make it easier for contributors to [write plugins](https://github.com/millermedeiros/esformatter/wiki/Plugins) and fix bugs.

![screen shot 2016-07-13 at 12 57 54 pm](https://cloud.githubusercontent.com/assets/155633/16818046/97aefade-48fa-11e6-8b1c-881ba7e0158c.png)