### PR TITLE
flow-parser: Update to v0.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint2": "file:packages/eslint2",
     "espree": "^3.1.0",
     "esprima": "^2.7.3",
-    "flow-parser": "^0.28.0",
+    "flow-parser": "^0.32.0",
     "font-awesome": "^4.5.0",
     "graphql": "^0.7.0",
     "halting-problem": "^1.0.2",


### PR DESCRIPTION
Flow v0.32.0 introduces new syntax, so a new version of `flow-parser` is out and it would be useful here.