### PR TITLE
build: fix for Node 6

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,7 @@ var plugins = [
 
       return fs.readFileSync('./index.html', 'utf-8');
     },
+    filename: 'index.html',
     favicon: './favicon.png',
     inject: 'body',
   }),


### PR DESCRIPTION
The exception `Path must be a string` comes from `html-webpack-plugin`, v1.7.0, [this line](https://github.com/ampedandwired/html-webpack-plugin/blob/v1.7.0/index.js#L205).

Passing `filename` explicitly fixes it.

Closes #137