### PR TITLE
Update jscodeshift default

### DIFF
--- a/src/parsers/js/transformers/jscodeshift/codeExample.txt
+++ b/src/parsers/js/transformers/jscodeshift/codeExample.txt
@@ -9,4 +9,4 @@ export default function transformer(file, api) {
       );
     })
     .toSource();
-};
+}

--- a/src/parsers/js/transformers/jscodeshift/codeExample.txt
+++ b/src/parsers/js/transformers/jscodeshift/codeExample.txt
@@ -1,11 +1,12 @@
 export default function transformer(file, api) {
   const j = api.jscodeshift;
-  const {expression, statement, statements} = j.template;
 
   return j(file.source)
     .find(j.Identifier)
-    .replaceWith(
-      p => j.identifier(p.node.name.split('').reverse().join(''))
-    )
+    .forEach(path => {
+      j(path).replaceWith(
+        j.identifier(path.node.name.split('').reverse().join(''))
+      );
+    })
     .toSource();
 };


### PR DESCRIPTION
A few changes to hopefully make it more beginner friendly

- Rename the variable `p` to `path` to make it more explicit
- Add `{}` inside of the arrow function in order to be able to add `console.log` more easily
- Use `forEach` instead of directly `replaceWith` as it's extremely likely that the codemod the person is going to write is not going to be as straightforward as just replacing a node with another one.
- Remove the default template stuff. I looked for [cpojer/js-codemods](https://github.com/cpojer/js-codemod) & [reactjs/react-codemod](https://github.com/reactjs/react-codemod) and there isn't a single use of those. We should document how they work and get people to use it, but I don't think it is useful to keep them by default.
- Remove the last `;` as it triggers a lint error on cpojer/js-codemods

I believe that this is going to be make the default experience more developer friendly. Let me know what you think :)

cc @fkling 