### PR TITLE
Use production RawGit URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,5 +35,5 @@
     </script>
     <script async src='https://www.google-analytics.com/analytics.js'></script>
     <!-- End Google Analytics -->
-  <script src="https://rawgit.com/fkling/astexplorer/gh-pages/vendor-1ea330d5574f59ce03f8.js"></script><script src="https://rawgit.com/fkling/astexplorer/gh-pages/style-d0c9a1ca29e5359dc581.js"></script><script src="https://rawgit.com/fkling/astexplorer/gh-pages/app-ce15eed93799e6afec98.js"></script></body>
+  <script src="https://cdn.rawgit.com/fkling/astexplorer/gh-pages/vendor-1ea330d5574f59ce03f8.js"></script><script src="https://cdn.rawgit.com/fkling/astexplorer/gh-pages/style-d0c9a1ca29e5359dc581.js"></script><script src="https://cdn.rawgit.com/fkling/astexplorer/gh-pages/app-ce15eed93799e6afec98.js"></script></body>
 </html>


### PR DESCRIPTION
RawGit.com suggests using the `cdn.` subdomain on assets which are not
subject to change. The non-cdn URLs are subject to throttling or rate limiting.