### PR TITLE
add a name, remove parameter destructuring [skip ci]

### DIFF
--- a/src/parsers/js/transformers/babel6/codeExample.txt
+++ b/src/parsers/js/transformers/babel6/codeExample.txt
@@ -1,5 +1,8 @@
-export default function ({types: t}) {
+export default function (babel) {
+  let { types: t } = babel;
+  
   return {
+    name: "ast-transform", // not required
     visitor: {
       Identifier(path) {
         path.node.name = path.node.name.split('').reverse().join('');

--- a/src/parsers/js/transformers/babel6/codeExample.txt
+++ b/src/parsers/js/transformers/babel6/codeExample.txt
@@ -1,5 +1,5 @@
 export default function (babel) {
-  let { types: t } = babel;
+  const { types: t } = babel;
   
   return {
     name: "ast-transform", // not required


### PR DESCRIPTION
and maybe we should actually use babel.types somehow?