### PR TITLE
add links for missing homepage urls

### DIFF
--- a/src/parsers/css/cssom.js
+++ b/src/parsers/css/cssom.js
@@ -9,7 +9,7 @@ export default {
   id: ID,
   displayName: ID,
   version: pkg.version,
-  homepage: pkg.homepage,
+  homepage: pkg.homepage || 'https://github.com/NV/CSSOM',
   locationProps: new Set(['__starts', '__ends']),
 
   loadParser(callback) {

--- a/src/parsers/css/rework.js
+++ b/src/parsers/css/rework.js
@@ -9,7 +9,7 @@ export default {
   id: ID,
   displayName: ID,
   version: pkg.version,
-  homepage: pkg.homepage,
+  homepage: pkg.homepage || 'https://github.com/reworkcss/rework',
   locationProps: new Set(['position']),
 
   loadParser(callback) {

--- a/src/parsers/html/htmlparser2.js
+++ b/src/parsers/html/htmlparser2.js
@@ -20,7 +20,7 @@ export default {
   id: ID,
   displayName: ID,
   version: pkg.version,
-  homepage: pkg.homepage,
+  homepage: pkg.homepage || 'https://github.com/fb55/htmlparser2',
   locationProps: new Set(['startIndex']),
 
   loadParser(callback) {

--- a/src/parsers/js/flow.js
+++ b/src/parsers/js/flow.js
@@ -27,7 +27,7 @@ export default {
   id: ID,
   displayName: ID,
   version: pkg.version,
-  homepage: pkg.homepage,
+  homepage: pkg.homepage || 'https://flowtype.org/',
   locationProps: new Set(['range', 'loc']),
 
   loadParser(callback) {

--- a/src/parsers/js/transformers/jscodeshift/index.js
+++ b/src/parsers/js/transformers/jscodeshift/index.js
@@ -9,7 +9,7 @@ export default {
   id: ID,
   displayName: ID,
   version: pkg.version,
-  homepage: pkg.homepage,
+  homepage: pkg.homepage || 'https://github.com/facebook/jscodeshift',
 
   defaultParserID: 'recast',
 

--- a/src/parsers/webidl/webidl2.js
+++ b/src/parsers/webidl/webidl2.js
@@ -18,7 +18,7 @@ export default {
   id: ID,
   displayName: ID,
   version: pkg.version,
-  homepage: pkg.homepage,
+  homepage: pkg.homepage || 'https://github.com/w3c/webidl2.js',
 
   getNodeName(node) {
     if (node.name) {


### PR DESCRIPTION
I saw that a few of the links were missing for various parsers/transformers.  I went ahead and added fallbacks for the missing homepages.  A better fix would be to submit PR's to the upstream repos so each package.json has a `homepage` value, but this is an okay stopgap IMO.

Here are the packages and the homepages I included:

https://www.npmjs.com/package/cssom - https://github.com/NV/CSSOM
https://www.npmjs.com/package/rework - https://github.com/reworkcss/rework
https://www.npmjs.com/package/htmlparser2 - https://github.com/fb55/htmlparser2
https://www.npmjs.com/package/flow - https://flowtype.org/
https://www.npmjs.com/package/jscodeshift - https://github.com/facebook/jscodeshift
https://www.npmjs.com/package/webidl2 - https://github.com/w3c/webidl2.js

Thanks for this great project @fkling !
