### PR TITLE
moving toolbar buttons to components/buttons

### DIFF
--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import cx from 'classnames';
-import CategoryButton from './CategoryButton';
-import ParserButton from './ParserButton';
-import TransformButton from './TransformButton';
+import CategoryButton from './components/buttons/CategoryButton';
+import ForkButton from './components/buttons/ForkButton';
+import ParserButton from './components/buttons/ParserButton';
+import SaveButton from './components/buttons/SaveButton';
+import TransformButton from './components/buttons/TransformButton';
 
 export default function Toolbar(props) {
   let {parser, transformer, showTransformer} = props;
@@ -32,40 +33,8 @@ export default function Toolbar(props) {
   return (
     <div id="Toolbar">
       <h1>AST Explorer</h1>
-      <button
-        type="button"
-        disabled={
-          !props.canSave || props.saving || props.forking
-        }
-        onClick={props.onSave}>
-        <i
-          className={cx({
-            fa: true,
-            'fa-spinner': props.saving,
-            'fa-floppy-o': !props.saving,
-            'fa-lg': true,
-            'fa-fw': true,
-          })}
-        />
-        Save
-      </button>
-      <button
-        type="button"
-        disabled={
-          !props.canFork || props.saving || props.forking
-        }
-        onClick={props.onFork}>
-        <i
-          className={cx({
-            fa: true,
-            'fa-spinner': props.forking,
-            'fa-code-fork': !props.forking,
-            'fa-lg': true,
-            'fa-fw': true,
-          })}
-        />
-        Fork
-      </button>
+      <SaveButton {...props} />
+      <ForkButton {...props} />
       <CategoryButton {...props} />
       <ParserButton {...props} />
       <TransformButton {...props} />
@@ -98,4 +67,3 @@ Toolbar.propTypes = {
   canSave: React.PropTypes.bool,
   canFork: React.PropTypes.bool,
 };
-

--- a/src/components/buttons/CategoryButton.js
+++ b/src/components/buttons/CategoryButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'classnames';
-import {getCategoryByID, categories} from './parsers';
+import {getCategoryByID, categories} from '../../parsers';
 
 const categoryIcon = {
   javascript: 'fa-jsfiddle',

--- a/src/components/buttons/ForkButton.js
+++ b/src/components/buttons/ForkButton.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import cx from 'classnames';
+
+export default class ForkButton extends React.Component {
+  render() {
+    const { canFork, saving, forking, onFork } = this.props;
+    return (
+      <button
+        type="button"
+        disabled={
+          !canFork || saving || forking
+        }
+        onClick={onFork}>
+        <i
+          className={cx({
+            fa: true,
+            'fa-spinner': forking,
+            'fa-code-fork': !forking,
+            'fa-lg': true,
+            'fa-fw': true,
+          })}
+        />
+        Fork
+      </button>
+    );
+  }
+}
+
+ForkButton.propTypes = {
+  canFork: React.PropTypes.bool,
+  saving: React.PropTypes.bool,
+  forking: React.PropTypes.bool,
+  onFork: React.PropTypes.func,
+};

--- a/src/components/buttons/ParserButton.js
+++ b/src/components/buttons/ParserButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {getParserByID} from './parsers';
+import {getParserByID} from '../../parsers';
 
 export default class ParserButton extends React.Component {
   constructor(props) {

--- a/src/components/buttons/SaveButton.js
+++ b/src/components/buttons/SaveButton.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import cx from 'classnames';
+
+export default class SaveButton extends React.Component {
+  render() {
+    const { canSave, saving, forking, onSave } = this.props;
+    return (
+      <button
+        type="button"
+        disabled={
+          !canSave || saving || forking
+        }
+        onClick={onSave}>
+        <i
+          className={cx({
+            fa: true,
+            'fa-spinner': saving,
+            'fa-floppy-o': !saving,
+            'fa-lg': true,
+            'fa-fw': true,
+          })}
+        />
+        Save
+      </button>
+    );
+  }
+}
+
+SaveButton.propTypes = {
+  canSave: React.PropTypes.bool,
+  saving: React.PropTypes.bool,
+  forking: React.PropTypes.bool,
+  onSave: React.PropTypes.func,
+};

--- a/src/components/buttons/TransformButton.js
+++ b/src/components/buttons/TransformButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'classnames';
-import {getTransformerByID} from './parsers';
+import {getTransformerByID} from '../../parsers';
 
 export default class TransformButton extends React.Component {
   constructor(props) {


### PR DESCRIPTION
Feel free to close/ignore this PR.  It's a very small refactor where I put all the toolbar buttons in their own folder.  There were already 3 buttons that existed: `CategoryButton`, `ParserButton`, `TransformButton`. I moved the 2 other `<div />` tags into their own components: `SaveButton` and `ForkButton`;