### PR TITLE
Upgrade to flow-parser@0.38.0

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -62,7 +62,7 @@
     "eslint2": "file:packages/eslint2",
     "espree": "^3.1.0",
     "esprima": "^3.1.3",
-    "flow-parser": "^0.37.0",
+    "flow-parser": "^0.38.0",
     "font-awesome": "^4.5.0",
     "graphql": "^0.8.2",
     "halting-problem": "^1.0.2",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -193,10 +193,6 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-
 ast-types@0.8.18:
   version "0.8.18"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.18.tgz#c8b98574898e8914e9d8de74b947564a9fe929af"
@@ -2474,9 +2470,17 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-parser@^0.*, flow-parser@^0.37.0:
+flow-parser@^0.*:
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.37.0.tgz#1065c612a30f037ac3ee60053f6e797a6d9be8d6"
+  dependencies:
+    ast-types "0.8.18"
+    colors ">=0.6.2"
+    minimist ">=0.2.0"
+
+flow-parser@^0.38.0:
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.38.0.tgz#a631c46170c5b42400d905a75cfc83ce8db29424"
   dependencies:
     ast-types "0.8.18"
     colors ">=0.6.2"
@@ -4564,20 +4568,11 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"


### PR DESCRIPTION
the yarn.lock has a few more changes than I initially expected. it looks like because flow-parser@0.37.0 required ast-types@0.18.15, yarn chose to install recast@0.10.43 which also uses that dependency. now, flow-parser@0.38.0 requires ast-types@0.18.18 and yarn thinks recast is better off using the older 0.10.33 that depends on ast-types@0.18.12 which it already has. there's probably no version of recast that depends on ast-types@0.18.18.

I ran this with yarn 0.19.1