### PR TITLE
fix path to ../out directory

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -97,7 +97,7 @@
     "yaml-ast-parser": "^0.0.31"
   },
   "scripts": {
-    "start": "http-server out",
+    "start": "http-server ../out",
     "build": "rimraf ../out/* && cross-env NODE_ENV=production webpack",
     "watch": "webpack -dw",
     "push": "./scripts/push-site.sh",


### PR DESCRIPTION
Now that the folder structure has been re-organized, I tried:
```
cd website;
yarn start;
```
Which no longer served the website. This fixes the path to the `out` folder.