### PR TITLE
Update defs

### DIFF
--- a/scripts/defs/jscodeshift.yaml
+++ b/scripts/defs/jscodeshift.yaml
@@ -172,9 +172,9 @@
         '!type': 'fn() -> NodePath'
       insertAt:
         '!type': 'fn(index: number, node: ASTNode)'
-      inserBefore:
+      insertBefore:
         '!type': 'fn(node: ASTNode)'
-      inserAfter:
+      insertAfter:
         '!type': 'fn(node: ASTNode)'
   ASTNode:
     type:

--- a/website/src/defs/jscodeshift.json
+++ b/website/src/defs/jscodeshift.json
@@ -939,10 +939,10 @@
         "insertAt": {
           "!type": "fn(index: number, node: ASTNode)"
         },
-        "inserBefore": {
+        "insertBefore": {
           "!type": "fn(node: ASTNode)"
         },
-        "inserAfter": {
+        "insertAfter": {
           "!type": "fn(node: ASTNode)"
         }
       }


### PR DESCRIPTION
Correct two typos in `scripts/defs/jsdoceshift.yaml` and in the generated `website/src/defs/jscodeshift.json`.  I could not figure out how to run `definition-generator.js`, so I had to fix the errors in the json by hand. :/