### PR TITLE
Add prettier to JSCodeshiftEditor

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -487,3 +487,17 @@ body .CodeMirror-Tern-tooltip {
   padding: 5px;
   width: calc(100% - 10px);
 }
+
+.toggleBtn {
+  position: absolute;
+  right: 0;
+  height: 20px;
+  z-index: 10;
+  cursor: pointer;
+  outline: none;
+}
+
+.toggleBtn > .btnText {
+  padding-left: 5px;
+  font-size: 12px;
+}

--- a/website/package.json
+++ b/website/package.json
@@ -85,6 +85,7 @@
     "postcss-less": "^0.15.0",
     "postcss-safe-parser": "^2.0.0",
     "postcss-scss": "^0.4.1",
+    "prettier": "^0.22.0",
     "pubsub-js": "^1.4.2",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -3,7 +3,7 @@ import ASTOutputContainer from './containers/ASTOutputContainer';
 import CodeEditorContainer from './containers/CodeEditorContainer';
 import ErrorMessageContainer from './containers/ErrorMessageContainer';
 import GistBanner from './components/GistBanner';
-import LoadingIndictorContainer from './containers/LoadingIndicatorContainer';
+import LoadingIndicatorContainer from './containers/LoadingIndicatorContainer';
 import PasteDropTargetContainer from './containers/PasteDropTargetContainer';
 import PubSub from 'pubsub-js';
 import React from 'react';
@@ -36,7 +36,7 @@ function App(props) {
       <ErrorMessageContainer />
       <div className={'dropTarget' + (props.hasError ? ' hasError' : '')}>
         <PasteDropTargetContainer>
-        <LoadingIndictorContainer />
+        <LoadingIndicatorContainer />
         <SettingsDialogContainer />
         <ShareDialogContainer />
         <div id="root">

--- a/website/src/components/Editor.js
+++ b/website/src/components/Editor.js
@@ -1,6 +1,17 @@
 import CodeMirror from 'codemirror';
 import PubSub from 'pubsub-js';
 import React from 'react';
+import prettier from 'prettier';
+
+const defaultPrettierOptions = {
+  printWidth: 80,
+  tabWidth: 2,
+  singleQuote: false,
+  trailingComma: 'none',
+  bracketSpacing: true,
+  jsxBracketSameLine: false,
+  parser: 'babylon',
+};
 
 export default class Editor extends React.Component {
 
@@ -72,6 +83,17 @@ export default class Editor extends React.Component {
         readOnly: this.props.readOnly,
       }
     );
+
+    this._bindCMHandler('blur', instance => {
+      if (!this.props.enableFormatting) return;
+      const currValue = instance.doc.getValue();
+      const options = Object.assign({},
+        defaultPrettierOptions,
+        {
+          printWidth: instance.display.maxLineLength,
+        });
+      instance.doc.setValue(prettier.format(currValue, options));
+    });
 
     this._bindCMHandler('changes', () => {
       clearTimeout(this._updateTimer);
@@ -195,6 +217,7 @@ Editor.propTypes = {
   posFromIndex: React.PropTypes.func,
   error: React.PropTypes.object,
   mode: React.PropTypes.string,
+  enableFormatting: React.PropTypes.bool,
 };
 
 Editor.defaultProps = {

--- a/website/src/components/JSCodeshiftEditor.js
+++ b/website/src/components/JSCodeshiftEditor.js
@@ -1,20 +1,9 @@
-import prettier from 'prettier';
 import CodeMirror from 'codemirror';
 import React from 'react';
 import Editor from './Editor';
 
 import 'codemirror/addon/hint/show-hint.css';
 import 'codemirror/addon/tern/tern.css';
-
-const defaultPrettierOptions = {
-  printWidth: 80,
-  tabWidth: 2,
-  singleQuote: false,
-  trailingComma: "none",
-  bracketSpacing: true,
-  jsxBracketSameLine: false,
-  parser: 'babylon'
-};
 
 let server;
 
@@ -31,12 +20,6 @@ export default class JSCodeshiftEditor extends Editor {
       'Ctrl-Space': cm => server && server.complete(cm),
       'Ctrl-I': cm => server && server.showType(cm),
       'Ctrl-O': cm => server && server.showDocs(cm),
-    });
-
-    this.codeMirror.on('blur', (instance, event) => {
-      const currValue = instance.doc.getValue();
-      const options = Object.assign({}, defaultPrettierOptions, {printWidth: instance.display.maxLineLength});
-      instance.doc.setValue(prettier.format(currValue, options));
     });
 
     this._bindCMHandler('cursorActivity', cm => {

--- a/website/src/components/JSCodeshiftEditor.js
+++ b/website/src/components/JSCodeshiftEditor.js
@@ -1,9 +1,20 @@
+import prettier from 'prettier';
 import CodeMirror from 'codemirror';
 import React from 'react';
 import Editor from './Editor';
 
 import 'codemirror/addon/hint/show-hint.css';
 import 'codemirror/addon/tern/tern.css';
+
+const defaultPrettierOptions = {
+  printWidth: 80,
+  tabWidth: 2,
+  singleQuote: false,
+  trailingComma: "none",
+  bracketSpacing: true,
+  jsxBracketSameLine: false,
+  parser: 'babylon'
+};
 
 let server;
 
@@ -20,7 +31,13 @@ export default class JSCodeshiftEditor extends Editor {
       'Ctrl-Space': cm => server && server.complete(cm),
       'Ctrl-I': cm => server && server.showType(cm),
       'Ctrl-O': cm => server && server.showDocs(cm),
-    })
+    });
+
+    this.codeMirror.on('blur', (instance, event) => {
+      const currValue = instance.doc.getValue();
+      const options = Object.assign({}, defaultPrettierOptions, {printWidth: instance.display.maxLineLength});
+      instance.doc.setValue(prettier.format(currValue, options));
+    });
 
     this._bindCMHandler('cursorActivity', cm => {
       server && server.updateArgHints(cm);

--- a/website/src/components/Transformer.js
+++ b/website/src/components/Transformer.js
@@ -4,26 +4,33 @@ import PubSub from 'pubsub-js';
 import React from 'react';
 import SplitPane from './SplitPane';
 import TransformOutput from './TransformOutput';
+import PrettierButton from './buttons/PrettierButton';
 
 function resize() {
   PubSub.publish('PANEL_RESIZE');
 }
 
 export default function Transformer(props) {
-  const editor = React.createElement(
+  const plainEditor = React.createElement(
     props.transformer.id === 'jscodeshift' ? JSCodeshiftEditor : Editor,
     {
       highlight: false,
       value: props.transformCode,
       onContentChange: props.onContentChange,
+      enableFormatting: props.enableFormatting,
     }
   );
+
+  const formattingEditor = (<div>
+    <PrettierButton toggleFormatting={props.toggleFormatting} enableFormatting={props.enableFormatting}/>
+    {plainEditor}
+  </div>)
 
   return (
     <SplitPane
       className="splitpane"
       onResize={resize}>
-      {editor}
+      {formattingEditor}
       <TransformOutput
         transformer={props.transformer}
         transformCode={props.transformCode}
@@ -41,4 +48,6 @@ Transformer.propTypes = {
   code: React.PropTypes.string,
   mode: React.PropTypes.string,
   onContentChange: React.PropTypes.func,
+  toggleFormatting: React.PropTypes.func,
+  enableFormatting: React.PropTypes.bool,
 };

--- a/website/src/components/buttons/PrettierButton.js
+++ b/website/src/components/buttons/PrettierButton.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import cx from 'classnames';
+
+export default function PrettierButton(props) {
+  return (<button type="button"
+            className="toggleBtn"
+            onClick={props.toggleFormatting}>
+          <i
+            className={cx({
+              fa: true,
+              'fa-lg': true,
+              'fa-toggle-off': !props.enableFormatting,
+              'fa-toggle-on': props.enableFormatting,
+              'fa-fw': true,
+            })}
+          />
+          <span className="btnText">Prettier</span>
+      </button>);
+}
+
+PrettierButton.propTypes = {
+  toggleFormatting: React.PropTypes.func,
+  enableFormatting: React.PropTypes.bool,
+}

--- a/website/src/containers/TransformerContainer.js
+++ b/website/src/containers/TransformerContainer.js
@@ -1,6 +1,6 @@
 import {connect} from 'react-redux';
 import Transformer from '../components/Transformer';
-import {setTransformState} from '../store/actions';
+import {setTransformState, toggleFormatting} from '../store/actions';
 import * as selectors from '../store/selectors';
 
 function mapStateToProps(state) {
@@ -13,6 +13,7 @@ function mapStateToProps(state) {
     transformCode: selectors.getTransformCode(state),
     mode: selectors.getParser(state).category.id,
     code: selectors.getCode(state),
+    enableFormatting: selectors.getFormattingState(state),
   };
 }
 
@@ -20,6 +21,9 @@ function mapDispatchToProps(dispatch) {
   return {
     onContentChange: ({value, cursor}) => {
       dispatch(setTransformState({code: value, cursor}));
+    },
+    toggleFormatting: () => {
+      dispatch(toggleFormatting());
     },
   };
 }

--- a/website/src/store/actions.js
+++ b/website/src/store/actions.js
@@ -23,6 +23,7 @@ export const SAVE = 'SAVE';
 export const START_SAVE = 'START_SAVE';
 export const END_SAVE = 'END_SAVE';
 export const RESET = 'RESET';
+export const TOGGLE_FORMATTING = 'TOGGLE_FORMATTING';
 
 export function setParser(parser) {
   return {type: SET_PARSER, parser};
@@ -122,4 +123,8 @@ export function dropText(text, categoryId) {
 
 export function reset() {
   return {type: RESET};
+}
+
+export function toggleFormatting() {
+  return {type: TOGGLE_FORMATTING};
 }

--- a/website/src/store/reducers.js
+++ b/website/src/store/reducers.js
@@ -39,6 +39,8 @@ const initialState = {
     },
   },
 
+  enableFormatting: false,
+
 };
 
 /**
@@ -92,7 +94,13 @@ export function astexplorer(state=initialState, action) {
     parserPerCategory: parserPerCategory(state.parserPerCategory, action),
     parserSettings: parserSettings(state.parserSettings, action, state),
     workbench: workbench(state.workbench, action, state),
+    enableFormatting: format(state.enableFormatting, action, state),
   };
+}
+
+function format(state=initialState.enableFormatting, action) {
+  if (action.type === actions.TOGGLE_FORMATTING) return !state;
+  return state;
 }
 
 function workbench(state=initialState.workbench, action, fullState) {

--- a/website/src/store/selectors.js
+++ b/website/src/store/selectors.js
@@ -4,6 +4,10 @@ import {getParserByID, getTransformerByID} from '../parsers';
 
 // UI related
 
+export function getFormattingState(state) {
+  return state.enableFormatting;
+}
+
 export function getCursor(state) {
   return state.cursor;
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -117,6 +117,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.0.0.tgz#5404e93a544c4fec7f048262977bebfe3155e0c1"
+  dependencies:
+    color-convert "^1.0.0"
+
 ansi-styles@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
@@ -222,6 +228,17 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
+<<<<<<< HEAD
+=======
+ast-types@0.8.18:
+  version "0.8.18"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.18.tgz#c8b98574898e8914e9d8de74b947564a9fe929af"
+
+ast-types@0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.4.tgz#410d1f81890aeb8e0a38621558ba5869ae53c91b"
+
+>>>>>>> Add prettier to JSCodeshiftEditor
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
@@ -275,7 +292,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
+babel-code-frame@6.22.0, babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -1315,6 +1332,10 @@ babili-webpack-plugin@^0.0.11:
   dependencies:
     babylon "^6.1.21"
 
+babylon@6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
+
 babylon@^5.8.38:
   version "5.8.38"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-5.8.38.tgz#ec9b120b11bf6ccd4173a18bf217e60b79859ffd"
@@ -1527,7 +1548,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1642,7 +1663,7 @@ codemirror@^5.22.0:
   version "5.24.2"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.24.2.tgz#b55ca950fa009709c37df68eb133310ed89cf2fe"
 
-color-convert@^1.3.0:
+color-convert@^1.0.0, color-convert@^1.3.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
   dependencies:
@@ -2569,13 +2590,13 @@ estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
 
+esutils@2.0.2, esutils@^2.0.0, esutils@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
 esutils@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.1.6.tgz#c01ccaa9ae4b897c6d0c3e210ae52f3c7a844375"
-
-esutils@^2.0.0, esutils@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
 event-emitter@~0.3.5:
   version "0.3.5"
@@ -2838,6 +2859,10 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-stdin@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -2878,7 +2903,7 @@ glob@5.0.x, glob@^5.0.14, glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
+glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -3436,6 +3461,22 @@ iterall@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.0.3.tgz#e0b31958f835013c323ff0b10943829ac69aa4b7"
 
+jest-matcher-utils@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz#5ecd9b63565d2b001f61fbf7ec4c7f537964564d"
+  dependencies:
+    chalk "^1.1.3"
+    pretty-format "^19.0.0"
+
+jest-validate@19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-19.0.0.tgz#8c6318a20ecfeaba0ba5378bfbb8277abded4173"
+  dependencies:
+    chalk "^1.1.1"
+    jest-matcher-utils "^19.0.0"
+    leven "^2.0.0"
+    pretty-format "^19.0.0"
+
 jodid25519@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
@@ -3585,6 +3626,10 @@ lcid@^1.0.0:
 leven@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/leven/-/leven-1.0.2.tgz#9144b6eebca5f1d0680169f1a6770dcea60b75c3"
+
+leven@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -4012,7 +4057,11 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
+<<<<<<< HEAD
 minimist@^1.1.0, minimist@^1.2.0:
+=======
+minimist@1.2.0, minimist@>=0.2.0, minimist@^1.1.0, minimist@^1.2.0:
+>>>>>>> Add prettier to JSCodeshiftEditor
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -4729,12 +4778,33 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-0.22.0.tgz#7b37c4480d0858180407e5a8e13f0f47da7385d2"
+  dependencies:
+    ast-types "0.9.4"
+    babel-code-frame "6.22.0"
+    babylon "6.15.0"
+    chalk "1.1.3"
+    esutils "2.0.2"
+    flow-parser "0.40.0"
+    get-stdin "5.0.1"
+    glob "7.1.1"
+    jest-validate "19.0.0"
+    minimist "1.2.0"
+
 pretty-error@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.0.3.tgz#bed3d816a008e76da617cde8216f4b778849b5d9"
   dependencies:
     renderkid "^2.0.1"
     utila "~0.4"
+
+pretty-format@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-19.0.0.tgz#56530d32acb98a3fa4851c4e2b9d37b420684c84"
+  dependencies:
+    ansi-styles "^3.0.0"
 
 private@^0.1.6, private@~0.1.5:
   version "0.1.7"


### PR DESCRIPTION
This allows prettier to run on the JSCodeshiftEditor. I'm not sure if 'blur' is the right time to run this honestly but at the very least I'm wondering if it's worth adding prettier to astexplorer.net somehow (maybe as a togglable option?). I definitely currently spend a lot of time just formatting code within the in-browser editor.