### PR TITLE
[eslint] Clean up eslint and babel-eslint

### DIFF
--- a/website/src/components/buttons/ParserButton.js
+++ b/website/src/components/buttons/ParserButton.js
@@ -13,6 +13,7 @@ export default class ParserButton extends React.Component {
   }
 
   render() {
+    const parsers = this.props.category.parsers.filter(p => p.showInMenu);
     return (
       <div className="button menuButton">
         <span>
@@ -20,7 +21,7 @@ export default class ParserButton extends React.Component {
           &nbsp;{this.props.parser.displayName}
         </span>
         <ul>
-          {this.props.category.parsers.map(parser => (
+          {parsers.map(parser => (
             <li key={parser.id} onClick={this._onClick} data-id={parser.id}>
               <button type="button" >
                 {parser.displayName}

--- a/website/src/parsers/js/acorn-to-esprima.js
+++ b/website/src/parsers/js/acorn-to-esprima.js
@@ -1,0 +1,59 @@
+import defaultParserInterface from './utils/defaultESTreeParserInterface';
+import pkg from 'acorn-to-esprima/package.json';
+
+const ID = 'acorn-to-esprima';
+const name = 'acorn-to-esprima';
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: name,
+  version: pkg.version,
+  homepage: pkg.homepage,
+  locationProps: new Set(['loc', 'start', 'end', 'range']),
+  showInMenu: false,
+
+  loadParser(callback) {
+    require(['acorn-to-esprima', 'babel5'], (acornToEsprima, {acorn: {tokTypes}, traverse, parse}) => {
+      callback({
+        ...acornToEsprima,
+        tokTypes,
+        traverse,
+        parse,
+      });
+    });
+  },
+
+  parse(parser, code) {
+    const opts = {
+      locations: true,
+      ranges: true,
+    };
+
+    const comments = opts.onComment = [];
+    const tokens = opts.onToken = [];
+
+    let ast = parser.parse(code, opts);
+
+    ast.tokens = parser.toTokens(tokens, parser.tokTypes);
+    parser.convertComments(comments);
+    ast.comments = comments;
+    parser.attachComments(ast, comments, ast.tokens);
+    parser.toAST(ast, parser.traverse);
+
+    return ast;
+  },
+
+  nodeToRange(node) {
+    if (typeof node.start !== 'undefined') {
+      return [node.start, node.end];
+    }
+  },
+
+  _ignoredProperties: new Set([
+    '_paths',
+    '_babelType',
+    '__clone',
+  ]),
+};

--- a/website/src/parsers/js/babel-eslint.js
+++ b/website/src/parsers/js/babel-eslint.js
@@ -1,7 +1,7 @@
 import defaultParserInterface from './utils/defaultESTreeParserInterface';
-import pkg from 'acorn-to-esprima/package.json';
+import pkg from 'babel-eslint/package.json';
 
-const ID = 'acorn-to-esprima';
+const ID = 'babel-eslint';
 const name = 'babel-eslint';
 
 export default {
@@ -14,33 +14,16 @@ export default {
   locationProps: new Set(['loc', 'start', 'end', 'range']),
 
   loadParser(callback) {
-    require(['acorn-to-esprima', 'babel5'], (acornToEsprima, {acorn: {tokTypes}, traverse, parse}) => {
-      callback({
-        ...acornToEsprima,
-        tokTypes,
-        traverse,
-        parse,
-      });
-    });
+    require(['babel-eslint'], babelEslint => callback(babelEslint));
   },
 
   parse(parser, code) {
     const opts = {
-      locations: true,
-      ranges: true,
+      sourceType: 'module',
     };
 
-    const comments = opts.onComment = [];
-    const tokens = opts.onToken = [];
-
-    let ast = parser.parse(code, opts);
-
-    ast.tokens = parser.toTokens(tokens, parser.tokTypes);
-    parser.convertComments(comments);
-    ast.comments = comments;
-    parser.attachComments(ast, comments, ast.tokens);
-    parser.toAST(ast, parser.traverse);
-
+    const ast = parser.parseNoPatch(code, opts);
+    delete ast.tokens;
     return ast;
   },
 

--- a/website/src/parsers/js/transformers/eslint2/index.js
+++ b/website/src/parsers/js/transformers/eslint2/index.js
@@ -9,7 +9,7 @@ export default {
   version: pkg.version,
   homepage: pkg.homepage,
 
-  defaultParserID: 'espree',
+  defaultParserID: 'babel-eslint',
 
   loadTransformer(callback) {
     require(

--- a/website/src/parsers/js/transformers/eslint3/index.js
+++ b/website/src/parsers/js/transformers/eslint3/index.js
@@ -9,7 +9,7 @@ export default {
   version: pkg.version,
   homepage: pkg.homepage,
 
-  defaultParserID: 'espree',
+  defaultParserID: 'babel-eslint',
 
   loadTransformer(callback) {
     require(

--- a/website/src/parsers/js/utils/eslintUtils.js
+++ b/website/src/parsers/js/utils/eslintUtils.js
@@ -26,7 +26,9 @@ export function defineRule(eslintRules, code) {
 export function runRule(code, eslint, sourceCode) {
   // Run the ESLint rule on the AST of the provided code.
   // Reference: http://eslint.org/docs/developer-guide/nodejs-api
-  const ast = parseNoPatch(code, {});
+  const ast = parseNoPatch(code, {
+    sourceType: 'module',
+  });
   const results = eslint.verify(new sourceCode(code, ast), {
     env: {es6: true},
     parserOptions: {

--- a/website/src/parsers/utils/defaultParserInterface.js
+++ b/website/src/parsers/utils/defaultParserInterface.js
@@ -1,4 +1,5 @@
 export default {
+  showInMenu: true,
   _ignoredProperties: new Set(),
   locationProps: new Set(),
 


### PR DESCRIPTION
The eslint setup in astexplorer is a bit chaotic. I'm not sure if it's worth investing a lot of time to clean this up in the light of  #197 (which I will hopefully finish some day 😛 ), so I just did some minimal changes:

- Switch the default parser for eslint2 and eslint3 to `babel-eslint`, because that's what `eslintUtils` uses.
- Enable `sourceType: 'module'` in `eslintUtils`.
- Make the `babel-eslint` parser actually refer to `babel-eslint` and not `acorn-to-esprima`.
- Since `acorn-to-esprima` is deprecated, hide in from the menu.

In order to really clean this up, `eslint1` would have to use an older version of `babel-eslint` that uses `acorn-to-esprima`, but I didn't want to spend more time with this.

@hzoo , does this look good?

cc @kentcdodds (follow up to #219 )