### PR TITLE
Update glimmer packages to 0.25.1.

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -38,8 +38,8 @@
     "webpack-chunk-hash": "^0.4.0"
   },
   "dependencies": {
-    "@glimmer/compiler": "^0.22.0",
-    "@glimmer/syntax": "^0.22.0",
+    "@glimmer/compiler": "^0.25.1",
+    "@glimmer/syntax": "^0.25.1",
     "acorn": "^5.0.3",
     "acorn-jsx": "^4.0.1",
     "acorn-to-esprima": "^1.0.2",

--- a/website/src/parsers/handlebars/glimmer.js
+++ b/website/src/parsers/handlebars/glimmer.js
@@ -9,7 +9,7 @@ export default {
   id: ID,
   displayName: ID,
   version: pkg.version,
-  homepage: pkg.homepage || 'https://github.com/tildeio/glimmer',
+  homepage: pkg.homepage || 'https://github.com/glimmerjs/glimmer-vm',
 
   loadParser(callback) {
     require(['@glimmer/syntax'], (glimmer) => callback(glimmer.preprocess));

--- a/website/src/parsers/handlebars/transformers/glimmer-compiler/codeExample.txt
+++ b/website/src/parsers/handlebars/transformers/glimmer-compiler/codeExample.txt
@@ -1,11 +1,11 @@
-module.exports = class {
-  transform(ast) {
-    this.syntax.traverse(ast, {
+module.exports = function() {
+  return {
+    name: 'ast-transform',
+
+    visitors: {
       ElementNode(node) {
         node.tag = node.tag.split('').reverse().join('');
       }
-    });
-
-    return ast;
-  }
+    }
+  };
 };

--- a/website/src/parsers/handlebars/transformers/glimmer-compiler/index.js
+++ b/website/src/parsers/handlebars/transformers/glimmer-compiler/index.js
@@ -7,7 +7,7 @@ export default {
   id: ID,
   displayName: ID,
   version: pkg.version,
-  homepage: pkg.homepage || 'https://github.com/tildeio/glimmer',
+  homepage: pkg.homepage || 'https://github.com/glimmerjs/glimmer-vm',
 
   defaultParserID: 'glimmer',
 

--- a/website/src/parsers/handlebars/transformers/glimmer/codeExample.txt
+++ b/website/src/parsers/handlebars/transformers/glimmer/codeExample.txt
@@ -1,11 +1,11 @@
-module.exports = class {
-  transform(ast) {
-    this.syntax.traverse(ast, {
+module.exports = function() {
+  return {
+    name: 'ast-transform',
+
+    visitors: {
       ElementNode(node) {
         node.tag = node.tag.split('').reverse().join('');
       }
-    });
-
-    return ast;
-  }
+    }
+  };
 };

--- a/website/src/parsers/handlebars/transformers/glimmer/index.js
+++ b/website/src/parsers/handlebars/transformers/glimmer/index.js
@@ -7,7 +7,7 @@ export default {
   id: ID,
   displayName: ID,
   version: pkg.version,
-  homepage: pkg.homepage || 'https://github.com/tildeio/glimmer',
+  homepage: pkg.homepage || 'https://github.com/glimmerjs/glimmer-vm',
 
   defaultParserID: 'glimmer',
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2,31 +2,40 @@
 # yarn lockfile v1
 
 
-"@glimmer/compiler@^0.22.0":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.22.1.tgz#70a8a3064ca4d62b15fc3c870ead11e6c7fb00bf"
+"@glimmer/compiler@^0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.25.1.tgz#81fb9f51349f819525da737ae953a5f8461fdef1"
   dependencies:
-    "@glimmer/syntax" "^0.22.1"
-    "@glimmer/util" "^0.22.1"
-    "@glimmer/wire-format" "^0.22.1"
+    "@glimmer/interfaces" "^0.25.1"
+    "@glimmer/syntax" "^0.25.1"
+    "@glimmer/util" "^0.25.1"
+    "@glimmer/wire-format" "^0.25.1"
     simple-html-tokenizer "^0.3.0"
 
-"@glimmer/syntax@^0.22.0", "@glimmer/syntax@^0.22.1":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.22.1.tgz#b4048738fa55c46e337278b2aeb37731509ae284"
+"@glimmer/interfaces@^0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.25.1.tgz#234abbbf7021a73ec576943443768d0e2801ad13"
   dependencies:
+    "@glimmer/wire-format" "^0.25.1"
+
+"@glimmer/syntax@^0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.25.1.tgz#05bbc219af98adc447195d4d74bba6fb9f5fd3d5"
+  dependencies:
+    "@glimmer/interfaces" "^0.25.1"
+    "@glimmer/util" "^0.25.1"
     handlebars "^4.0.6"
     simple-html-tokenizer "^0.3.0"
 
-"@glimmer/util@^0.22.1":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.22.1.tgz#7be751f77325ac857327f9c786ee2d02fba4d4e1"
+"@glimmer/util@^0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.25.1.tgz#bdc669de4cae562eb797fb29714da4d290ec58c1"
 
-"@glimmer/wire-format@^0.22.1":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.22.1.tgz#2673bbb1e89805194e9870064c6905af21406ffb"
+"@glimmer/wire-format@^0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.25.1.tgz#cd69f3595a08954fa68a3f1df4feafffa1c3f3de"
   dependencies:
-    "@glimmer/util" "^0.22.1"
+    "@glimmer/util" "^0.25.1"
 
 "@types/node@^6.0.46":
   version "6.0.73"


### PR DESCRIPTION
The format of the AST transforms changed, this adjusts to the new format.