### PR TITLE
Add typescript-eslint-parser

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -92,7 +92,7 @@
     "postcss-less": "^1.0.1",
     "postcss-safe-parser": "^3.0.0",
     "postcss-scss": "^1.0.0",
-    "prettier": "^1.3.1",
+    "prettier": "~1.3.1",
     "prop-types": "^15.5.10",
     "pubsub-js": "^1.4.2",
     "query-string": "^4.3.4",
@@ -112,7 +112,8 @@
     "sqlite-parser": "^1.0.0-rc3",
     "tern": "^0.20.0",
     "traceur": "0.0.111",
-    "typescript": "2.3",
+    "typescript": "2.4.0",
+    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#ts-2.4",
     "uglify-loader": "^2.0.0",
     "webidl2": "^3.0.2",
     "yaml-ast-parser": "^0.0.32"

--- a/website/src/parsers/js/typescript-eslint-parser.js
+++ b/website/src/parsers/js/typescript-eslint-parser.js
@@ -1,0 +1,26 @@
+import defaultParserInterface from './utils/defaultESTreeParserInterface';
+import pkg from 'typescript-eslint-parser/package.json';
+
+const ID = 'typescript-eslint-parser';
+const name = pkg.name;
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: name,
+  version: pkg.version,
+  homepage: pkg.homepage,
+  locationProps: new Set(['loc', 'start', 'end', 'range']),
+
+  loadParser(callback) {
+    require(['typescript-eslint-parser'], callback);
+  },
+
+  parse(parser, code) {
+    const opts = {};
+    const ast = parser.parse(code, opts);
+    delete ast.tokens;
+    return ast;
+  },
+};

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -28,10 +28,6 @@ const plugins = [
 
   // Prettier //
 
-  // typescript-eslint-parser is a dev dependency of prettier, so it's not
-  // installed by default but prettier does still require it. See
-  // https://github.com/prettier/prettier/issues/986
-  new webpack.IgnorePlugin(/typescript-eslint-parser/, /\/prettier/),
   // We don't use the flow parser with prettier, so we don't need to include it
   new webpack.IgnorePlugin(/^flow-parser/, /\/prettier/),
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4142,6 +4142,10 @@ lodash.toplainobject@^3.0.0:
     lodash._basecopy "^3.0.0"
     lodash.keysin "^3.0.0"
 
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -5083,7 +5087,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.3.1:
+prettier@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.3.1.tgz#fa0ea84b45ac0ba6de6a1e4cecdcff900d563151"
   dependencies:
@@ -5725,7 +5729,7 @@ schema-utils@^0.3.0, schema-utils@^0.x:
   dependencies:
     ajv "^5.0.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
@@ -6264,9 +6268,16 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.3.tgz#9639f3c3b40148e8ca97fe08a51dd1891bb6be22"
+"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#ts-2.4":
+  version "3.0.0"
+  resolved "git://github.com/eslint/typescript-eslint-parser.git#cfddbfe3ebf550530aef2f1c6c4ea1d9e738d9c1"
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.3.0"
+
+typescript@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.0.tgz#aef5a8d404beba36ad339abf079ddddfffba86dd"
 
 ua-parser-js@^0.7.9:
   version "0.7.12"


### PR DESCRIPTION
Hi guys, thanks for this awesome tool! It is incredibly useful when working on prettier.

`typescript-eslint-parser` is the parser prettier uses for TypeScript support, and it would be great if ASTExplorer could host it too.

The parser aims to be a superset of ESTree, so it should be pretty low-maintenance. 