### PR TITLE
Avoid compiling to ES5 in TransformOutput component

### DIFF
--- a/website/src/components/TransformOutput.js
+++ b/website/src/components/TransformOutput.js
@@ -3,44 +3,20 @@ import Editor from './Editor';
 import JSONEditor from './JSONEditor';
 import PropTypes from 'prop-types';
 import React from 'react';
-import halts, {loopProtect} from 'halting-problem';
 import {SourceMapConsumer} from 'source-map/lib/source-map-consumer';
 
 import stringify from 'json-stringify-safe';
 
-function loadJSTransformer(callback) {
-  require(['../parsers/utils/transformJSCode'], toES5 => callback(toES5.default));
-}
 
 function transform(transformer, transformCode, code) {
   if (!transformer._promise) {
-    transformer._promise = Promise.all([
-      new Promise(transformer.loadTransformer),
-      new Promise(loadJSTransformer),
-    ]);
+    transformer._promise = new Promise(transformer.loadTransformer)
   }
   // Use Promise.resolve(null) to return all errors as rejected promises
-  return transformer._promise.then(([realTransformer, toES5]) => {
-    let es5Code = toES5(transformCode);
-    // assert that there are no obvious infinite loops
-    halts(es5Code);
-    // guard against non-obvious loops with a timeout of 5 seconds
-    let start = Date.now();
-    es5Code = loopProtect(
-      es5Code,
-      [
-        // this function gets called in all possible loops
-        // it gets passed the line number as its only argument
-        '(function (line) {',
-        'if (Date.now() > ' + (start + 5000) + ') {',
-        '  throw new Error("Infinite loop detected on line " + line);',
-        '}',
-        '})',
-      ].join('')
-    );
+  return transformer._promise.then(realTransformer => {
     let result = transformer.transform(
       realTransformer,
-      es5Code,
+      transformCode,
       code
     );
     return Promise.resolve(result).then(result => {

--- a/website/src/parsers/js/transformers/babel/index.js
+++ b/website/src/parsers/js/transformers/babel/index.js
@@ -1,5 +1,6 @@
 import compileModule from '../../../utils/compileModule';
 import pkg from 'babel5/babel5-package';
+import toES5 from '../../../utils/toES5.js';
 
 const ID = 'babel';
 
@@ -15,15 +16,17 @@ export default {
     require(['babel5'], callback);
   },
 
-  transform(babel, transformCode, code) {
-    let transform = compileModule( // eslint-disable-line no-shadow
-      transformCode
-    );
+  transform(babel, originalTransformCode, code) {
+    return toES5(originalTransformCode).then(transformCode => {
+      let transform = compileModule( // eslint-disable-line no-shadow
+        transformCode
+      );
 
-    return babel.transform(code, {
-      whitelist: [],
-      plugins: [transform.default || transform],
-      sourceMaps: true,
+      return babel.transform(code, {
+        whitelist: [],
+        plugins: [transform.default || transform],
+        sourceMaps: true,
+      });
     });
   },
 };

--- a/website/src/parsers/utils/toES5.js
+++ b/website/src/parsers/utils/toES5.js
@@ -1,0 +1,27 @@
+import halts, {loopProtect} from 'halting-problem';
+
+function loadJSTransformer(callback) {
+  require(['./transformJSCode'], toES5 => callback(toES5.default));
+}
+
+export default code => new Promise(loadJSTransformer).then(toES5 => {
+  let es5Code = toES5(code);
+  // assert that there are no obvious infinite loops
+  halts(es5Code);
+  // guard against non-obvious loops with a timeout of 5 seconds
+  let start = Date.now();
+  es5Code = loopProtect(
+    es5Code,
+    [
+      // this function gets called in all possible loops
+      // it gets passed the line number as its only argument
+      '(function (line) {',
+      'if (Date.now() > ' + (start + 5000) + ') {',
+      '  throw new Error("Infinite loop detected on line " + line);',
+      '}',
+      '})',
+    ].join('')
+  );
+
+  return es5Code;
+});


### PR DESCRIPTION
As discussed in #248, `TransformOutput` automatically tries to compile the transform code to ES5.

This makes it impossible to provide transformers in languages other than JavaScript.

This PR extracts the `toES5` step into a separate utility, to be explicitly invoked by transformers that need it. I've provided an example of what it would look like for the `babel` transformer. If the approach is deemed ok, I'll port this to all the existing transformers.

