### PR TITLE
Use uglify-es instead of submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "packages/uglify2-harmony"]
-	path = website/packages/uglify2-harmony
-	url = https://github.com/mishoo/UglifyJS2.git
-	branch = harmony

--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ as possible!
 #### Build your own version for development
 
 1. Clone the repository.
-2. Run `git submodule update --init` to initialize / update all submodules.
 3. Go to `website/`.
 4. Install all dependencies with `yarn install` (you can run `npm install` as
    well).

--- a/website/package.json
+++ b/website/package.json
@@ -115,6 +115,7 @@
     "traceur": "0.0.111",
     "typescript": "2.4",
     "typescript-eslint-parser": "^3.0.0",
+    "uglify-es": "^3.0.28",
     "uglify-loader": "^2.0.0",
     "webidl2": "^3.0.2",
     "yaml-ast-parser": "^0.0.32"

--- a/website/src/parsers/js/uglify.js
+++ b/website/src/parsers/js/uglify.js
@@ -1,5 +1,5 @@
 import defaultParserInterface from '../utils/defaultParserInterface';
-import pkg from '../../../packages/uglify2-harmony/package.json';
+import pkg from '../../../node_modules/uglify-es/package.json';
 import compileModule from '../utils/compileModule';
 
 const ID = 'uglify-js';
@@ -15,9 +15,9 @@ export default {
 
   loadParser(callback) {
     require([
-      'raw-loader!../../../packages/uglify2-harmony/lib/utils.js',
-      'raw-loader!../../../packages/uglify2-harmony/lib/ast.js',
-      'raw-loader!../../../packages/uglify2-harmony/lib/parse.js',
+      'raw-loader!../../../node_modules/uglify-es/lib/utils.js',
+      'raw-loader!../../../node_modules/uglify-es/lib/ast.js',
+      'raw-loader!../../../node_modules/uglify-es/lib/parse.js',
     ], (...contents) => {
       contents.push('exports.parse = parse;');
       callback(compileModule(contents.join('\n\n')));

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1743,6 +1743,10 @@ commander@2.9.x, commander@^2.5.0, commander@~2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@~2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -6235,6 +6239,13 @@ typescript@2.4:
 ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
+
+uglify-es@^3.0.28:
+  version "3.0.28"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.0.28.tgz#1cdedbbcdb7865223065281ad7b2347629851d4b"
+  dependencies:
+    commander "~2.11.0"
+    source-map "~0.5.1"
 
 uglify-js@3.0.x:
   version "3.0.13"


### PR DESCRIPTION
uglify-es is now released from the "harmony" branch of
https://github.com/mishoo/UglifyJS2.git, so it should be equivalent.

See https://github.com/mishoo/UglifyJS2/tree/067d52b6bac67378cccbc8fdea2320676aafc47e