### PR TITLE
Add Hide type keys option

### DIFF
--- a/website/src/components/visualization/Tree.js
+++ b/website/src/components/visualization/Tree.js
@@ -58,6 +58,14 @@ export default class Tree extends React.Component {
             />
           Hide location data
           </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={this.state.hideTypeKeys}
+              onChange={this._setOption.bind(this, 'hideTypeKeys')}
+            />
+          Hide type keys
+          </label>
         </div>
         <ul onMouseLeave={() => {PubSub.publish('CLEAR_HIGHLIGHT');}}>
           <Element

--- a/website/src/components/visualization/tree/Element.js
+++ b/website/src/components/visualization/tree/Element.js
@@ -140,12 +140,13 @@ let Element = class extends React.Component {
   }
 
   _getProperties(parser, value) {
-    const {hideFunctions, hideEmptyKeys, hideLocationData} = this.props.settings;
+    const {hideFunctions, hideEmptyKeys, hideLocationData, hideTypeKeys} = this.props.settings;
     let properties = [...parser.forEachProperty(value)];
     return properties
       .filter(({value}) => !hideFunctions || typeof value !== 'function')
       .filter(({value}) => !hideEmptyKeys || value != null)
-      .filter(({key}) => !hideLocationData || !parser.locationProps.has(key));
+      .filter(({key}) => !hideLocationData || !parser.locationProps.has(key))
+      .filter(({key}) => !hideTypeKeys || key !== 'type');
   }
 
   _execFunction() {


### PR DESCRIPTION
The type keys seem redundant, added an option to hide them, making the AST more readable:
<img width="1434" alt="screenshot 2017-09-30 22 19 53" src="https://user-images.githubusercontent.com/1473433/31049582-f85300ce-a62d-11e7-8c11-80153659903e.png">
