### PR TITLE
Add ability to customize key mappings to editor

### DIFF
--- a/website/src/components/Editor.js
+++ b/website/src/components/Editor.js
@@ -1,4 +1,7 @@
 import CodeMirror from 'codemirror';
+import 'codemirror/keymap/vim';
+import 'codemirror/keymap/emacs';
+import 'codemirror/keymap/sublime';
 import PropTypes from 'prop-types';
 import PubSub from 'pubsub-js';
 import React from 'react';
@@ -32,6 +35,11 @@ export default class Editor extends React.Component {
     if (nextProps.mode !== this.props.mode) {
       this.codeMirror.setOption('mode', nextProps.mode);
     }
+
+    if (nextProps.keyMap !== this.props.keyMap) {
+      this.codeMirror.setOption('keyMap', nextProps.keyMap);
+    }
+
     this._setError(nextProps.error);
   }
 
@@ -77,6 +85,7 @@ export default class Editor extends React.Component {
     this.codeMirror = CodeMirror( // eslint-disable-line new-cap
       this.container,
       {
+        keyMap: this.props.keyMap,
         value: this.state.value,
         mode: this.props.mode,
         lineNumbers: this.props.lineNumbers,
@@ -220,6 +229,7 @@ Editor.propTypes = {
   error: PropTypes.object,
   mode: PropTypes.string,
   enableFormatting: PropTypes.bool,
+  keyMap: PropTypes.string,
 };
 
 Editor.defaultProps = {
@@ -228,6 +238,7 @@ Editor.defaultProps = {
   lineNumbers: true,
   readOnly: false,
   mode: 'javascript',
+  keyMap: 'default',
   onContentChange: () => {},
   onActivity: () => {},
 };

--- a/website/src/components/JSCodeshiftEditor.js
+++ b/website/src/components/JSCodeshiftEditor.js
@@ -88,6 +88,7 @@ JSCodeshiftEditor.propTypes = {
   posFromIndex: PropTypes.func,
   error: PropTypes.object,
   mode: PropTypes.string,
+  keyMap: PropTypes.string,
 };
 
 JSCodeshiftEditor.defaultProps = Object.assign(

--- a/website/src/components/Toolbar.js
+++ b/website/src/components/Toolbar.js
@@ -4,6 +4,7 @@ import CategoryButton from './buttons/CategoryButton';
 import ParserButton from './buttons/ParserButton';
 import SnippetButton from './buttons/SnippetButton';
 import TransformButton from './buttons/TransformButton';
+import KeyMapButton from './buttons/KeyMapButton';
 
 export default function Toolbar(props) {
   let {parser, transformer, showTransformer} = props;
@@ -37,6 +38,7 @@ export default function Toolbar(props) {
       <CategoryButton {...props} />
       <ParserButton {...props} />
       <TransformButton {...props} />
+      <KeyMapButton {...props} />
       <a
         style={{minWidth: 0}}
         target="_blank" rel="noopener noreferrer"
@@ -61,6 +63,7 @@ Toolbar.propTypes = {
   onParserSettingsButtonClick: PropTypes.func,
   onShareButtonClick: PropTypes.func,
   onTransformChange: PropTypes.func,
+  onKeyMapChange: PropTypes.func,
   parser: PropTypes.object,
   transformer: PropTypes.object,
   showTransformer: PropTypes.bool,

--- a/website/src/components/Transformer.js
+++ b/website/src/components/Transformer.js
@@ -19,6 +19,7 @@ export default function Transformer(props) {
       value: props.transformCode,
       onContentChange: props.onContentChange,
       enableFormatting: props.enableFormatting,
+      keyMap: props.keyMap,
     }
   );
 
@@ -37,6 +38,7 @@ export default function Transformer(props) {
         transformCode={props.transformCode}
         code={props.code}
         mode={props.mode}
+        keyMap={props.keyMap}
       />
     </SplitPane>
   );
@@ -48,6 +50,7 @@ Transformer.propTypes = {
   transformer: PropTypes.object,
   code: PropTypes.string,
   mode: PropTypes.string,
+  keyMap: PropTypes.string,
   onContentChange: PropTypes.func,
   toggleFormatting: PropTypes.func,
   enableFormatting: PropTypes.bool,

--- a/website/src/components/buttons/KeyMapButton.js
+++ b/website/src/components/buttons/KeyMapButton.js
@@ -1,0 +1,47 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import cx from 'classnames';
+
+const keyMappings = ['default', 'vim', 'emacs', 'sublime']
+
+class KeyMapButton extends React.Component {
+  render() {
+    return (
+      <div className={cx({
+        button: true,
+        menuButton: true,
+      })}>
+        <button
+          type="button">
+          <i
+            className={cx({
+              fa: true,
+              'fa-lg': true,
+              'fa-keyboard-o': true,
+            })}
+          />
+          &nbsp;{this.props.keyMap}
+        </button>
+        {<ul>
+          {keyMappings.map(keyMap => (
+            <li
+              key={keyMap}
+              disabled={this.props.keyMap === keyMap}
+              onClick={() => this.props.onKeyMapChange(keyMap)}>
+              <button type="button" >
+                {keyMap}
+              </button>
+            </li>
+          ))}
+        </ul>}
+      </div>
+    );
+  }
+}
+
+KeyMapButton.propTypes = {
+  onKeyMapChange: PropTypes.func,
+  keyMap: PropTypes.string,
+}
+
+export default KeyMapButton

--- a/website/src/containers/CodeEditorContainer.js
+++ b/website/src/containers/CodeEditorContainer.js
@@ -1,10 +1,11 @@
 import {connect} from 'react-redux';
 import {setCode, setCursor} from '../store/actions';
 import Editor from '../components/Editor';
-import {getCode, getParser, getParseError} from '../store/selectors';
+import {getCode, getParser, getParseError, getKeyMap} from '../store/selectors';
 
 function mapStateToProps(state) {
   return {
+    keyMap: getKeyMap(state),
     value: getCode(state),
     mode: getParser(state).category.id,
     error: getParseError(state),

--- a/website/src/containers/ToolbarContainer.js
+++ b/website/src/containers/ToolbarContainer.js
@@ -8,6 +8,7 @@ import {
   hideTransformer,
   setParser,
   reset,
+  setKeyMap,
 } from '../store/actions';
 import Toolbar from '../components/Toolbar';
 import * as selectors from '../store/selectors';
@@ -24,6 +25,7 @@ function mapStateToProps(state) {
     category: parser.category,
     parser,
     transformer: selectors.getTransformer(state),
+    keyMap: selectors.getKeyMap(state),
     showTransformer: selectors.showTransformer(state),
     snippet: selectors.getRevision(state),
   };
@@ -51,6 +53,12 @@ function mapDispatchToProps(dispatch) {
       dispatch(transformer ? selectTransformer(transformer) : hideTransformer());
       if (transformer) {
         logEvent('tool', 'select', transformer.id);
+      }
+    },
+    onKeyMapChange: keyMap => {
+      dispatch(setKeyMap(keyMap))
+      if (keyMap) {
+        logEvent('keyMap', keyMap);
       }
     },
     onSave: () => dispatch(save(false)),

--- a/website/src/containers/TransformerContainer.js
+++ b/website/src/containers/TransformerContainer.js
@@ -14,6 +14,7 @@ function mapStateToProps(state) {
     mode: selectors.getParser(state).category.id,
     code: selectors.getCode(state),
     enableFormatting: selectors.getFormattingState(state),
+    keyMap: selectors.getKeyMap(state),
   };
 }
 

--- a/website/src/store/actions.js
+++ b/website/src/store/actions.js
@@ -24,6 +24,7 @@ export const START_SAVE = 'START_SAVE';
 export const END_SAVE = 'END_SAVE';
 export const RESET = 'RESET';
 export const TOGGLE_FORMATTING = 'TOGGLE_FORMATTING';
+export const SET_KEY_MAP = 'SET_KEY_MAP';
 
 export function setParser(parser) {
   return {type: SET_PARSER, parser};
@@ -127,4 +128,8 @@ export function reset() {
 
 export function toggleFormatting() {
   return {type: TOGGLE_FORMATTING};
+}
+
+export function setKeyMap(keyMap) {
+  return {type: SET_KEY_MAP, keyMap}
 }

--- a/website/src/store/reducers.js
+++ b/website/src/store/reducers.js
@@ -31,6 +31,7 @@ const initialState = {
     parserSettings: {},
     parseError: null,
     code: defaultParser.category.codeExample,
+    keyMap: 'default',
     initialCode: defaultParser.category.codeExample,
     transform: {
       code: '',
@@ -50,7 +51,7 @@ export function persist(state) {
   return {
     ...pick(state, 'showTransformPanel', 'parserSettings', 'parserPerCategory'),
     workbench: {
-      ...pick(state.workbench, 'parser', 'code'),
+      ...pick(state.workbench, 'parser', 'code', 'keyMap'),
       transform: pick(state.workbench.transform, 'code', 'transformer'),
     },
   };
@@ -231,6 +232,8 @@ function workbench(state=initialState.workbench, action, fullState) {
         }
         return newState;
       }
+    case actions.SET_KEY_MAP:
+      return {...state, keyMap: action.keyMap};
     default:
       return state;
   }

--- a/website/src/store/selectors.js
+++ b/website/src/store/selectors.js
@@ -63,6 +63,11 @@ export function getInitialCode(state) {
   return state.workbench.initialCode;
 }
 
+export function getKeyMap (state) {
+  return state.workbench.keyMap;
+}
+
+
 const isCodeDirty = createSelector(
   [getCode, getInitialCode],
   (code, initialCode) => code !== initialCode


### PR DESCRIPTION
First, thanks so much for this project! It's made my journey diving into the world of ASTs so much easier.

This pull request adds the ability to customize the key mapping for the `Editor` and `JSCodeShiftEditor` CodeMirror instances with mappings for `emacs`, `sublime`, and (last but not least) `vim`.


![screen shot 2017-10-14 at 11 15 33 am](https://user-images.githubusercontent.com/1290336/31577298-a3710d86-b0d1-11e7-9127-4315af993619.png)

![keymaps-demo-loop](https://user-images.githubusercontent.com/1290336/31577379-dc49014e-b0d2-11e7-891f-90d661060a91.gif)


Things to note:
---

- I went ahead and just stuck another button on the top row; this works but I'd be open to exploring a more meta "options page" if that's a good fit
- Because `Editor` and `JSCodeShiftEditor` share the same class but have different containers I had to duplicate some prop passing; let me know if there's a better way
- I'm not a fantastic designer, let me know if there's a preferred pattern for this UI


Things I tested:
---
- [x] Switching between parser types (css/js/php)
- [x] Switching between transformers
- [x] Switching between bindings (default -> vim -> default -> emacs)
- [x] Reloading (setting is persisted)


Size
---

Also, including these additional mappings does increase the build size for app but it is not significant IMHO:

```
App.js Size
---

before: app-7c94119c6a8277cce7d2-12.js     255 kB                50  [emitted]  [big]  app
after: app-badfe3b7918172f4e390-12.js     258 kB                50  [emitted]  [big]  app

Total Bytes (`perl -le 'map { $sum += -s } @ARGV; print $sum' -- ../out/*.js`)
---

before: 29016829
after: 29121463
```

Thanks!