### PR TITLE
Add TSLint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ are included so you can prototype your own plugins:
   - [babel][] (v5, v6)
   - [ESLint][] (v1, v2, v3)
   - [jscodeshift][]
+  - [tslint][]
 - CSS
   - [postcss][]
 - Regular Expressions
@@ -119,6 +120,7 @@ node.
 [traceur]: https://github.com/google/traceur-compiler
 [typescript]: https://github.com/Microsoft/TypeScript/
 [typescript-eslint-parser]: https://github.com/eslint/typescript-eslint-parser/
+[tslint]: https://palantir.github.io/tslint/
 [uglify-js]: https://github.com/mishoo/UglifyJS2
 [webidl]: https://github.com/darobin/webidl2.js
 [remark]: https://github.com/wooorm/remark

--- a/website/package.json
+++ b/website/package.json
@@ -121,7 +121,7 @@
     "yaml-ast-parser": "^0.0.39"
   },
   "scripts": {
-    "start": "http-server $NODE_DEBUG_OPTION ../out",
+    "start": "http-server ../out",
     "build": "rimraf ../out/* && cross-env NODE_ENV=production webpack",
     "watch": "webpack -dw",
     "lint": "eslint src/",

--- a/website/package.json
+++ b/website/package.json
@@ -112,6 +112,7 @@
     "sqlite-parser": "^1.0.0-rc3",
     "tern": "^0.20.0",
     "traceur": "0.0.111",
+    "tslint": "5.8.0",
     "typescript": "~2.6.1",
     "typescript-eslint-parser": "^9.0.0",
     "uglify-es": "^3.0.28",
@@ -120,7 +121,7 @@
     "yaml-ast-parser": "^0.0.39"
   },
   "scripts": {
-    "start": "http-server ../out",
+    "start": "http-server $NODE_DEBUG_OPTION ../out",
     "build": "rimraf ../out/* && cross-env NODE_ENV=production webpack",
     "watch": "webpack -dw",
     "lint": "eslint src/",

--- a/website/src/parsers/js/transformers/tslint/codeExample.txt
+++ b/website/src/parsers/js/transformers/tslint/codeExample.txt
@@ -1,11 +1,11 @@
 exports.Rule = class Rule extends Lint.Rules.AbstractRule {
   apply(sourceFile) {
-    return this.applyWithWalker(new NoImportsWalker(sourceFile, this.getOptions()));
+    return this.applyWithWalker(new NoTemplateExpressionWalker(sourceFile, this.getOptions()));
   }
 };
 
 // The walker takes care of all the work.
-class NoImportsWalker extends Lint.RuleWalker {
+class NoTemplateExpressionWalker extends Lint.RuleWalker {
   visitTemplateExpression(node) {
     // create a failure at the current position
     this.addFailure(this.createFailure(node.getStart(), node.getWidth(), "Do not use template literals"));

--- a/website/src/parsers/js/transformers/tslint/codeExample.txt
+++ b/website/src/parsers/js/transformers/tslint/codeExample.txt
@@ -1,0 +1,16 @@
+exports.Rule = class Rule extends Lint.Rules.AbstractRule {
+  apply(sourceFile) {
+    return this.applyWithWalker(new NoImportsWalker(sourceFile, this.getOptions()));
+  }
+};
+
+// The walker takes care of all the work.
+class NoImportsWalker extends Lint.RuleWalker {
+  visitTemplateExpression(node) {
+    // create a failure at the current position
+    this.addFailure(this.createFailure(node.getStart(), node.getWidth(), "Do not use template literals"));
+
+    // call the base version of this visitor to actually parse this node
+    super.visitTemplateExpression(node);
+  }
+}

--- a/website/src/parsers/js/transformers/tslint/index.js
+++ b/website/src/parsers/js/transformers/tslint/index.js
@@ -12,7 +12,7 @@ export default {
   defaultParserID: 'typescript',
 
   loadTransformer(callback) {
-    require(['tslint'], tslint => callback({tslint}));
+    require(['tslint/lib/index'], tslint => callback({tslint}));
   },
 
   transform({ tslint }, transformCode, code) {

--- a/website/src/parsers/js/transformers/tslint/index.js
+++ b/website/src/parsers/js/transformers/tslint/index.js
@@ -1,0 +1,48 @@
+import compileModule from '../../../utils/compileModule';
+import pkg from 'tslint/package.json';
+
+const ID = 'tslint';
+
+export default {
+  id: ID,
+  displayName: ID,
+  version: pkg.version,
+  homepage: pkg.homepage,
+
+  defaultParserID: 'typescript',
+
+  loadTransformer(callback) {
+    require(['tslint'], tslint => callback({tslint}));
+  },
+
+  transform({ tslint }, transformCode, code) {
+    let transform = compileModule( // eslint-disable-line no-shadow
+      transformCode,
+      { Lint: tslint }
+    );
+
+    let linter = new tslint.Linter({});
+    let rule = new transform.Rule({});
+    let sourceFile = linter.getSourceFile('astExplorer.ts', code);
+    let ruleFailures = linter.applyRule(rule, sourceFile);
+    
+    return formatResults(ruleFailures);
+  },
+};
+
+function formatResults(results) {
+  return results.length === 0
+    ? 'Lint rule not fired.'
+    : results.map(formatResult).join('').trim();
+}
+
+function formatResult(result) {
+  let { line, character } = result.startPosition.lineAndCharacter;
+  let rawLine = result.rawLines.split('\n')[line];
+  let pointer = '-'.repeat(character) + '^';
+  return `
+// ${result.failure} (at ${line+1}:${character+1})
+   ${rawLine}
+// ${pointer}
+`;
+}

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -160,6 +160,7 @@ module.exports = Object.assign({
           path.join(__dirname, 'node_modules', 'regexp-tree'),
           path.join(__dirname, 'node_modules', 'typescript-eslint-parser'),
           path.join(__dirname, 'node_modules', 'webidl2'),
+          path.join(__dirname, 'node_modules', 'tslint'),
           path.join(__dirname, 'src'),
         ],
         loader: 'babel-loader',

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -161,6 +161,7 @@ module.exports = Object.assign({
           path.join(__dirname, 'node_modules', 'typescript-eslint-parser'),
           path.join(__dirname, 'node_modules', 'webidl2'),
           path.join(__dirname, 'node_modules', 'tslint'),
+          path.join(__dirname, 'node_modules', 'tslib'),
           path.join(__dirname, 'src'),
         ],
         loader: 'babel-loader',


### PR DESCRIPTION
Hi.

This PR adds [TSLint](https://palantir.github.io/tslint/) (the Typescript Linter) as a transformer (issue #288).
Use it with the rule example that's in `tslint/codeExample.txt` to see it in action.

Right now though the rule itself can only be written in Javascript, not Typescript.
Ideally I'd like to support writing the rules in Typescript, as most TSLint users are accustomed to.
But I think this will require a change in how the `transformer.transform` is called.
Right now the original `transformCode` is turned into `es5Code` before the specific TSLint transformer is called, and by that point that conversion throws an error.

LMK if you need more info\changes.
Thanks.