### PR TITLE
Add pipelineOperator for Babylon7.

### DIFF
--- a/website/src/parsers/js/babylon7.js
+++ b/website/src/parsers/js/babylon7.js
@@ -23,6 +23,7 @@ const availablePlugins = [
   'typescript',
   'bigInt',
   'optionalCatchBinding',
+  'pipelineOperator',
 ];
 
 const ID = 'babylon7';

--- a/website/src/parsers/js/transformers/babel7/index.js
+++ b/website/src/parsers/js/transformers/babel7/index.js
@@ -44,6 +44,7 @@ export default {
           'importMeta',
           'bigInt',
           'optionalCatchBinding',
+          'pipelineOperator',
         ],
       },
       generatorOpts: {

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1788,6 +1788,10 @@ commander@2.9.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@^2.9.0:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -2169,6 +2173,10 @@ detective@^4.3.1:
   dependencies:
     acorn "^4.0.3"
     defined "^1.0.0"
+
+diff@^3.2.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -3101,7 +3109,7 @@ glob@5.0.x, glob@^5.0.14, glob@^5.0.15, glob@~5.0.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -6392,6 +6400,32 @@ tryit@^1.0.1:
 tryor@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/tryor/-/tryor-0.1.2.tgz#8145e4ca7caff40acde3ccf946e8b8bb75b4172b"
+
+tslib@^1.7.1, tslib@^1.8.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.1.tgz#6946af2d1d651a7b1863b531d6e5afa41aa44eac"
+
+tslint@5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.8.0.tgz#1f49ad5b2e77c76c3af4ddcae552ae4e3612eb13"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.1.0"
+    commander "^2.9.0"
+    diff "^3.2.0"
+    glob "^7.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.7.1"
+    tsutils "^2.12.1"
+
+tsutils@^2.12.1:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.13.1.tgz#d6d1cc0f7c04cf9fb3b28a292973cffb9cfbe09a"
+  dependencies:
+    tslib "^1.8.0"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
This PR just adds the pipelineOperator plugin for babylon7.
It's disabled by default, but could be enabled from the settings.

<img width="718" alt="screen shot 2017-12-20 at 16 10 03" src="https://user-images.githubusercontent.com/1521229/34210957-451896c4-e5a0-11e7-94ed-67c3559b360b.png">
