### PR TITLE
Add ecmaVersions 8 and 9 to Espree parser settings

### DIFF
--- a/website/src/parsers/js/espree.js
+++ b/website/src/parsers/js/espree.js
@@ -22,7 +22,7 @@ const defaultOptions = {
 };
 const parserSettingsConfiguration = {
   fields: [
-    ['ecmaVersion', [3, 5, 6, 7], value => Number(value)],
+    ['ecmaVersion', [3, 5, 6, 7, 8, 9], value => Number(value)],
     ['sourceType', ['script', 'module']],
     'range',
     'loc',


### PR DESCRIPTION
I'm writing an ESLint rule that deals with async/await. Currently, ecmaVersions 8 and 9 are not included in the Espree parser settings on astexplorer.net. This PR updates the Espree settings to include ecmaVersions 8 and 9, which are [supported by Espree 3.5.2](https://github.com/eslint/espree/tree/v3.5.2#usage) (this version is listed as the resolved dependency in the website's `yarn.lock` file).

https://github.com/fkling/astexplorer/blob/262c60f650e178c711ddba9b18c4be9f2f510c41/website/yarn.lock#L2695-L2700

## Before

async/await parsing error

![image](https://user-images.githubusercontent.com/2344137/35780187-dad7e2e0-09a5-11e8-94a0-c1f462fbdeaa.png)

![image](https://user-images.githubusercontent.com/2344137/35780189-e0ccbbe4-09a5-11e8-8408-750d8c3714cc.png)

## After

async/await parsed successfully

![image](https://user-images.githubusercontent.com/2344137/35780193-eea1e870-09a5-11e8-8eee-0222cbd8f037.png)

![image](https://user-images.githubusercontent.com/2344137/35780195-f70476d6-09a5-11e8-8498-3bce4f11fe02.png)
