### PR TITLE
Add babylon7 as an available parser for recast

### DIFF
--- a/website/packages/babylon7/package.json
+++ b/website/packages/babylon7/package.json
@@ -4,6 +4,6 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "babylon": "7.0.0-beta.31"
+    "babylon": "7.0.0-beta.44"
   }
 }

--- a/website/src/parsers/js/recast.js
+++ b/website/src/parsers/js/recast.js
@@ -4,7 +4,8 @@ import pkg from 'recast/package.json';
 import SettingsRenderer from '../utils/SettingsRenderer';
 
 import flowParser, * as flowSettings from './flow';
-import babylonParser, * as babylonSettings from './babylon6';
+import babylon6Parser, * as babylon6Settings from './babylon6';
+import babylon7Parser, * as babylon7Settings from './babylon7';
 
 const ID = 'recast';
 const defaultOptions = {
@@ -12,12 +13,13 @@ const defaultOptions = {
   range: true,
   parser: 'esprima',
   flow: flowSettings.defaultOptions,
-  babylon: babylonSettings.defaultOptions,
+  babylon6: babylon6Settings.defaultOptions,
+  babylon7: babylon7Settings.defaultOptions,
 };
 
 const parserSettingsConfiguration = {
   fields: [
-    ['parser', ['esprima', 'babel5', 'babylon6', 'flow']],
+    ['parser', ['esprima', 'babel5', 'babylon6', 'babylon7', 'flow']],
     'range',
     'tolerant',
     {
@@ -27,10 +29,16 @@ const parserSettingsConfiguration = {
       settings: settings => settings.flow || defaultOptions.flow,
     },
     {
-      key: 'babylon',
+      key: 'babylon6',
       title: 'Babylon 6 Settings',
-      fields: babylonSettings.parserSettingsConfiguration.fields,
-      settings: settings => settings.babylon || defaultOptions.babylon,
+      fields: babylon6Settings.parserSettingsConfiguration.fields,
+      settings: settings => settings.babylon6 || defaultOptions.babylon6,
+    },
+    {
+      key: 'babylon7',
+      title: 'Babylon 7 Settings',
+      fields: babylon7Settings.parserSettingsConfiguration.fields,
+      settings: settings => settings.babylon7 || defaultOptions.babylon7,
     },
   ],
   required: new Set(['range']),
@@ -47,13 +55,14 @@ export default {
 
   loadParser(callback) {
     require(
-      ['recast', 'babel5', 'babylon6', 'flow-parser'],
-      (recast, babelCore, babylon6, flow) => {
+      ['recast', 'babel5', 'babylon6', 'babylon7', 'flow-parser'],
+      (recast, babelCore, babylon6, babylon7, flow) => {
         callback({
           recast,
           parsers: {
             'babel5': babelCore,
             babylon6,
+            babylon7,
             flow,
           },
         });
@@ -64,9 +73,11 @@ export default {
   parse({ recast, parsers }, code, options) {
     options = {...defaultOptions, ...options};
     const flowOptions = options.flow;
-    const babylonOptions = options.babylon;
+    const babylon6Options = options.babylon6;
+    const babylon7Options = options.babylon7;
     delete options.flow;
-    delete options.babylon;
+    delete options.babylon6;
+    delete options.babylon7;
 
     switch (options.parser) {
       case 'esprima':
@@ -82,7 +93,14 @@ export default {
       case 'babylon6':
         options.parser = {
           parse(code) {
-            return babylonParser.parse(parsers.babylon6, code, babylonOptions);
+            return babylon6Parser.parse(parsers.babylon6, code, babylon6Options);
+          },
+        };
+        break;
+      case 'babylon7':
+        options.parser = {
+          parse(code) {
+            return babylon7Parser.parse(parsers.babylon7, code, babylon7Options);
           },
         };
         break;

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1322,15 +1322,15 @@ babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.26
 "babylon7@file:packages/babylon7":
   version "1.0.0"
   dependencies:
-    babylon "7.0.0-beta.31"
+    babylon "7.0.0-beta.44"
 
 babylon@7.0.0-beta.27:
   version "7.0.0-beta.27"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.27.tgz#b6edd30ef30619e2f630eb52585fdda84e6542cd"
 
-babylon@7.0.0-beta.31:
-  version "7.0.0-beta.31"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.31.tgz#7ec10f81e0e456fd0f855ad60fa30c2ac454283f"
+babylon@7.0.0-beta.44, babylon@^7.0.0-beta.30:
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
 
 babylon@^5.8.38:
   version "5.8.38"
@@ -1339,10 +1339,6 @@ babylon@^5.8.38:
 babylon@^6.1.21, babylon@^6.17.0, babylon@^6.18.0, babylon@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
-
-babylon@^7.0.0-beta.30:
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
 
 bail@^1.0.0:
   version "1.0.2"
@@ -1793,8 +1789,8 @@ commander@2.9.x:
     graceful-readlink ">= 1.0.0"
 
 commander@^2.9.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -6432,8 +6428,8 @@ tslint@5.8.0:
     tsutils "^2.12.1"
 
 tsutils@^2.12.1:
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.19.1.tgz#76d7ebdea9d7a7bf4a05f50ead3701b0168708d7"
+  version "2.21.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.21.1.tgz#5b23c263233300ed7442b4217855cbc7547c296a"
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
<img width="1125" alt="screen shot 2018-02-11 at 4 03 32 pm" src="https://user-images.githubusercontent.com/2177366/36080453-2f20acf2-0f45-11e8-9b36-b7370ec0134a.png">

This allows parsing TypeScript sources when the babylon@7 'typescript' plugin is used:
<img width="1125" alt="screen shot 2018-02-11 at 4 01 47 pm" src="https://user-images.githubusercontent.com/2177366/36080454-2f37dee0-0f45-11e8-8002-be1244f2d88f.png">

Once a [new version of jscodeshift is released to support TypeScript](https://github.com/facebook/jscodeshift/issues/180#issuecomment-364800400), this will be useful as a tool to author TypeScript transforms.