### PR TITLE
flow v0.72.0

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -71,7 +71,7 @@
     "eslint4": "file:packages/eslint4",
     "espree": "^3.1.0",
     "esprima": "^4.0.0",
-    "flow-parser": "^0.69.0",
+    "flow-parser": "^0.72.0",
     "font-awesome": "^4.5.0",
     "glsl-parser": "^2.0.0",
     "glsl-tokenizer": "^2.1.2",

--- a/website/src/parsers/js/flow.js
+++ b/website/src/parsers/js/flow.js
@@ -9,6 +9,8 @@ export const defaultOptions = {
   esproposal_class_static_fields: true,
   esproposal_decorators: true,
   esproposal_export_star_as: true,
+  esproposal_optional_chaining: true,
+  esproposal_nullish_coalescing: true,
   types: true,
 };
 export const parserSettingsConfiguration = {
@@ -17,6 +19,8 @@ export const parserSettingsConfiguration = {
     'esproposal_class_static_fields',
     'esproposal_decorators',
     'esproposal_export_star_as',
+    'esproposal_optional_chaining',
+    'esproposal_nullish_coalescing',
     'types',
   ],
 };

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2972,9 +2972,9 @@ flow-parser@^0.*:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.59.0.tgz#f6ebcae61ffa187e420999d40ce0a801f39b2635"
 
-flow-parser@^0.69.0:
-  version "0.69.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.69.0.tgz#378b5128d6d0b554a8b2f16a4ca3e1ab9649f00e"
+flow-parser@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.72.0.tgz#6c8041e76ac7d0be1a71ce29c00cd1435fb6013c"
 
 font-awesome@^4.5.0:
   version "4.7.0"


### PR DESCRIPTION
## Changes since the base of PR (v0.69.0)

### v0.72
* Added support for nullish coalescing `??`.
* Simplified object type parsing. Dangling `+` or `static` inside an object type (e.g. `{+}`) are now disallowed.
* Added support for a `proto` modifier in declare class, to specify that the property is a prototype property instead of a class one.
* Internal slot properties in object types (e.g. `[[new]]`).
* Explicit type arguments in new and call expressions, e.g., `f<T>(x)`.
* Allow reserved words as optional chain property names.

### v0.71
* The AST has been updated to use snake_case for record fields rather than camelCase. Some field names have also been updated.
* Support has been added for the [Numeric Separators proposal](https://github.com/tc39/proposal-numeric-separator), currently Stage 3.
* The AST representation for [Optional Chaining](https://github.com/tc39/proposal-optional-chaining) has been updated to use new `OptionalMember` and `OptionalCall` nodes instead of the existing `Member` and `Call` nodes, and parentheses now correctly limit the scope of short-circuiting. This reflects the current [Babel](https://github.com/babel/babel/issues/7256) implementation.

### v0.70
* Exposed `implements` and `mixins` fields of the `DeclareClass` AST node.
* Added `tokens` option to JS API: `flow.parse(..., { tokens: true })` will now return the token stream, like `flow ast --tokens` does.
* Added options support to the parser's C interface. This change lets you pass a map of options to the parser via the C++ API, and from JS via flow-parser-bin. You could already do this from the js_of_ocaml parser, so now their APIs match.