### PR TITLE
Fix jscodeshift with flow parser

### DIFF
--- a/website/src/parsers/js/transformers/jscodeshift/index.js
+++ b/website/src/parsers/js/transformers/jscodeshift/index.js
@@ -11,10 +11,10 @@ export default {
   version: pkg.version,
   homepage: pkg.homepage || 'https://github.com/facebook/jscodeshift',
 
-  defaultParserID: 'recast',
+  defaultParserID: 'flow',
 
   loadTransformer(callback) {
-    require(['jscodeshift'], jscodeshift => {
+    require(['jscodeshift', 'flow-parser'], (jscodeshift, flowParser) => {
         const { registerMethods } = jscodeshift;
 
         let origMethods;
@@ -37,13 +37,13 @@ export default {
           }
         };
 
-        callback({jscodeshift});
+        callback({jscodeshift, flowParser});
       }
     );
   },
 
   transform(
-    {jscodeshift},
+    {jscodeshift, flowParser},
     transformCode,
     code
   ) {
@@ -66,7 +66,7 @@ export default {
       {
         jscodeshift: transformModule.parser ?
           jscodeshift.withParser(transformModule.parser) :
-          jscodeshift,
+          jscodeshift.withParser(flowParser),
         stats: (value, quantity=1) => {
           statsWasCalled = true;
           counter[value] = (counter[value] ? counter[value] : 0) + quantity;


### PR DESCRIPTION
Using JScodeshift with the Flow parser broke due to the jscodeshift upgrade to v0.5.0 on April 2nd (a8344e10). 

This fix commit fixes it by passing the selected parser through to the transformer function, but I could have also simply loaded it as part of the loadTransformer function (similar to the babelv7 transformer).

Unexpected token error after the upgrade:
<img width="1512" alt="screen shot 2018-05-11 at 5 05 36 pm" src="https://user-images.githubusercontent.com/563800/39951315-91721ee8-553d-11e8-9623-9c47860562b1.png">


With the fix:
<img width="1512" alt="screen shot 2018-05-11 at 5 05 39 pm" src="https://user-images.githubusercontent.com/563800/39951318-9522e02c-553d-11e8-8edc-bb360b69f041.png">


