### PR TITLE
Add ecmaVersion option 9, 10 for acron

### DIFF
--- a/website/src/parsers/js/acorn.js
+++ b/website/src/parsers/js/acorn.js
@@ -60,7 +60,7 @@ export default {
   _getSettingsConfiguration() {
     return {
       fields: [
-        ['ecmaVersion', [3, 5, 6, 7, 8], x => Number(x)],
+        ['ecmaVersion', [3, 5, 6, 7, 8, 9, 10], x => Number(x)],
         ['sourceType', ['script', 'module']],
         'allowReserved',
         'allowReturnOutsideFunction',


### PR DESCRIPTION
acorn now support ecmaVersion 9 and 10.
And it need at least 9 to support for await of syntax.