### PR TITLE
Update `graphql` to latest stable release 0.13.2.

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -77,7 +77,7 @@
     "font-awesome": "^4.5.0",
     "glsl-parser": "^2.0.0",
     "glsl-tokenizer": "^2.1.2",
-    "graphql": "^0.11.7",
+    "graphql": "^0.13.2",
     "halting-problem": "^1.0.2",
     "handlebars": "^4.0.6",
     "htmlparser2": "^3.9.0",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3425,17 +3425,17 @@ graphql-request@^1.4.0:
   dependencies:
     cross-fetch "2.0.0"
 
-graphql@^0.11.7:
-  version "0.11.7"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.11.7.tgz#e5abaa9cb7b7cccb84e9f0836bf4370d268750c6"
-  dependencies:
-    iterall "1.1.3"
-
 graphql@^0.12.3:
   version "0.12.3"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.12.3.tgz#11668458bbe28261c0dcb6e265f515ba79f6ce07"
   dependencies:
     iterall "1.1.3"
+
+graphql@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
+  dependencies:
+    iterall "^1.2.1"
 
 halting-problem@^1.0.2:
   version "1.0.3"
@@ -4112,6 +4112,10 @@ isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
 iterall@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
+
+iterall@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
 
 js-base64@^2.1.9:
   version "2.4.5"


### PR DESCRIPTION
This brings the GraphQL parser up to date with the June 2018 version of
the GraphQL specification [[Ref 1]].  Amongst the features supported within
this newer version are string literal descriptions [[Ref 2]], so this
resolves fkling/astexplorer#312.

[Ref 1]: https://facebook.github.io/graphql/June2018/
[Ref 2]: https://facebook.github.io/graphql/June2018/#sec-Descriptions
Fixes: fkling/astexplorer#312