### PR TITLE
[babel-plugin-macros] Add "decoratorsBeforeExport" option when specifying decorators plugin

### DIFF
--- a/website/src/parsers/js/transformers/babel-plugin-macros/index.js
+++ b/website/src/parsers/js/transformers/babel-plugin-macros/index.js
@@ -33,7 +33,7 @@ export default {
           'asyncGenerators',
           'classPrivateProperties',
           'classProperties',
-          'decorators',
+          ['decorators', { decoratorsBeforeExport: false }],
           'doExpressions',
           'exportExtensions',
           'flow',


### PR DESCRIPTION
The "babel-plugin-macros" transform is currently erroring with: 

`The 'decorators' plugin requires a 'decoratorsBeforeExport' option, whose value must be a boolean.`

This should fix that.