### PR TITLE
Add full unprettified transformed MDX code below syntax error

### DIFF
--- a/website/src/parsers/mdx/transformers/mdx/index.js
+++ b/website/src/parsers/mdx/transformers/mdx/index.js
@@ -28,9 +28,21 @@ export default {
     const jsxCode = mdx.sync(code, {
       ...(transform.default || transform),
     });
-    return prettier.format(jsxCode, {
-      parser: 'babylon',
-      plugins: [babylon],
-    });
+    try {
+      return prettier.format(jsxCode, {
+        parser: 'babylon',
+        plugins: [babylon],
+      });
+    } catch (err) {
+      return `
+${err.message}
+
+------------
+Full output:
+------------
+
+${jsxCode.trim()}
+`.trim();
+    }
   },
 };


### PR DESCRIPTION
Now when Prettier can't parse the JSX, it prints the full unprettified JSX output below the error report, for easier debugging:

<img width="739" alt="screenshot 2019-01-16 at 01 04 03" src="https://user-images.githubusercontent.com/471278/51254827-2f45a300-19a2-11e9-9c21-41655cc98e39.png">
