### PR TITLE
Use custom resolvePath in babel-plugin-macros

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -57,7 +57,7 @@
     "babel-eslint": "^7.2.3",
     "babel-eslint8": "file:packages/babel-eslint8",
     "babel-eslint9": "file:packages/babel-eslint9",
-    "babel-plugin-macros": "^2.2.0",
+    "babel-plugin-macros": "^2.5.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",

--- a/website/src/parsers/js/transformers/babel-plugin-macros/index.js
+++ b/website/src/parsers/js/transformers/babel-plugin-macros/index.js
@@ -59,7 +59,7 @@ export default {
       generatorOpts: {
         generator: recast.print,
       },
-      plugins: [macro(babel, {require: () => transform})],
+      plugins: [macro(babel, {require: () => transform, resolvePath: src => src})],
       sourceMaps: true,
     });
   },

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1819,10 +1819,10 @@ babel-plugin-jscript@^1.0.4:
   resolved "https://registry.yarnpkg.com/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz#8f342c38276e87a47d5fa0a8bd3d5eb6ccad8fcc"
   integrity sha1-jzQsOCduh6R9X6CovT1etsytj8w=
 
-babel-plugin-macros@^2.2.0:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.4.5.tgz#7000a9b1f72d19ceee19a5804f1d23d6daf38c13"
-  integrity sha512-+/9yteNQw3yuZ3krQUfjAeoT/f4EAdn3ELwhFfDj0rTMIaoHfIdrcLePOfIaL0qmFLpIcgPIL2Lzm58h+CGWaw==
+babel-plugin-macros@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.5.0.tgz#01f4d3b50ed567a67b80a30b9da066e94f4097b6"
+  integrity sha512-BWw0lD0kVZAXRD3Od1kMrdmfudqzDzYv2qrN3l2ISR1HVp1EgLKfbOrYV9xmY5k3qx3RIu5uPAUZZZHpo0o5Iw==
   dependencies:
     cosmiconfig "^5.0.5"
     resolve "^1.8.1"


### PR DESCRIPTION
Fixes #380

Importing a module with the `babel-plugin-macros` transform threw an error because it uses the `fs` module (which is empty in ASTExplorer's build). `v.2.5.0` of `babel-plugin-macros` adds a `resolvePath` option that lets ASTExplorer bypass the `fs` call.