### PR TITLE
Add Solidity parser solidity-parser-antlr

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The AST explorer provides following code parsers:
   - [regexp-tree][]
 - Scala
   - [Scalameta][]
+- Solidity:
+  - [solidity-parser-antlr][]
 - SQL:
   - [sqlite-parser][]
 - [WebIDL][]
@@ -151,6 +153,7 @@ node.
 [mdxhast]: https://mdxjs.com/advanced/ast#mdxhast
 [mdx]: https://mdxjs.com/advanced/sync-api
 [Scalameta]: http://scalameta.org/
+[solidity-parser-antlr]: https://github.com/federicobond/solidity-parser-antlr
 
 ### Contributions
 

--- a/website/package.json
+++ b/website/package.json
@@ -121,6 +121,7 @@
     "reselect": "^3.0.1",
     "scalameta-parsers": "^2.0.0-RC3",
     "shift-parser": "^5.0.2",
+    "solidity-parser-antlr": "^0.4.0",
     "source-map": "^0.6.1",
     "sqlite-parser": "^1.0.0-rc3",
     "tern": "^0.20.0",

--- a/website/src/parsers/solididy/codeExample.txt
+++ b/website/src/parsers/solididy/codeExample.txt
@@ -1,0 +1,12 @@
+pragma solidity ^0.4.18;
+contract SimpleStore {
+  function set(uint _value) public {
+    value = _value;
+  }
+
+  function get() public constant returns (uint) {
+    return value;
+  }
+
+  uint value;
+}

--- a/website/src/parsers/solididy/index.js
+++ b/website/src/parsers/solididy/index.js
@@ -1,0 +1,6 @@
+import 'codemirror/mode/javascript/javascript';
+
+export const id = 'solididy';
+export const displayName = 'Solidity';
+export const mimeTypes = [];
+export const fileExtension = 'sol';

--- a/website/src/parsers/solididy/solidity-parser-antlr.js
+++ b/website/src/parsers/solididy/solidity-parser-antlr.js
@@ -31,7 +31,7 @@ export default {
     return {
       range: true,
       loc: false,
-      tolerant: false
+      tolerant: false,
     };
   },
 
@@ -40,10 +40,10 @@ export default {
       fields: [
         'range',
         'loc',
-        'tolerant'
-      ]
+        'tolerant',
+      ],
     };
-  }
+  },
 
 };
 

--- a/website/src/parsers/solididy/solidity-parser-antlr.js
+++ b/website/src/parsers/solididy/solidity-parser-antlr.js
@@ -1,0 +1,49 @@
+import pkg from 'solidity-parser-antlr/package.json';
+import defaultParserInterface from '../utils/defaultParserInterface';
+
+const ID = 'solidity-parser-antlr';
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: ID,
+  version: pkg.version,
+  homepage: pkg.homepage || 'https://github.com/federicobond/solidity-parser-antlr',
+
+  loadParser(callback) {
+    require(['solidity-parser-antlr'], callback);
+  },
+
+  parse(parser, code, options) {
+    return parser.parse(code, options);
+  },
+
+  opensByDefault(node, key) {
+    return node.type === 'SourceUnit' ||
+      node.type === 'ContractDefinition' ||
+      key === 'children' ||
+      key === 'subNodes' ||
+      key === 'body'
+  },
+
+  getDefaultOptions() {
+    return {
+      range: true,
+      loc: false,
+      tolerant: false
+    };
+  },
+
+  _getSettingsConfiguration() {
+    return {
+      fields: [
+        'range',
+        'loc',
+        'tolerant'
+      ]
+    };
+  }
+
+};
+

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8347,6 +8347,11 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+solidity-parser-antlr@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.4.0.tgz#005f38c396ca23cf7aada9b1a10d875176788201"
+  integrity sha512-RrIsh5VoHmrMQia6yLY8u8rx3JPREhSiCFz4Xb0h1Oh0prUYU2ukyWO8gG892V0UMHIXCWqvdZ3wSctNwdWThg==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"


### PR DESCRIPTION
Add [solidity-parser-antlr](https://github.com/federicobond/solidity-parser-antlr) parser for [Solidity](https://solidity.readthedocs.io/en/v0.5.3/index.html).
Pull request for issue #374