### PR TITLE
Add tokens option for Flow and Babylon parsers

### DIFF
--- a/website/src/parsers/js/babylon.js
+++ b/website/src/parsers/js/babylon.js
@@ -41,6 +41,7 @@ export default {
       allowReserved: false,
       allowReturnOutsideFunction: false,
       strictMode: false,
+      tokens: false,
 
       features: {
         'es7.asyncFunctions': true,
@@ -64,6 +65,7 @@ export default {
         'allowReserved',
         'allowReturnOutsideFunction',
         'strictMode',
+        'tokens',
         {
           key: 'features',
           title: 'Features',

--- a/website/src/parsers/js/babylon6.js
+++ b/website/src/parsers/js/babylon6.js
@@ -22,6 +22,7 @@ export const defaultOptions = {
   sourceType: 'module',
   allowImportExportEverywhere: false,
   allowReturnOutsideFunction: false,
+  tokens: false,
   plugins: [
     'asyncGenerators',
     'classConstructorCall',
@@ -43,6 +44,7 @@ export const parserSettingsConfiguration = {
     ['sourceType', ['module', 'script']],
     'allowReturnOutsideFunction',
     'allowImportExportEverywhere',
+    'tokens',
     {
       key: 'plugins',
       title: 'Plugins',

--- a/website/src/parsers/js/babylon7.js
+++ b/website/src/parsers/js/babylon7.js
@@ -43,6 +43,7 @@ export const defaultOptions = {
   allowImportExportEverywhere: false,
   allowReturnOutsideFunction: false,
   ranges: false,
+  tokens: false,
   plugins: [
     'asyncGenerators',
     'classProperties',
@@ -67,6 +68,7 @@ export const parserSettingsConfiguration = {
     'allowReturnOutsideFunction',
     'allowImportExportEverywhere',
     'ranges',
+    'tokens',
     {
       key: 'plugins',
       title: 'Plugins',

--- a/website/src/parsers/js/flow.js
+++ b/website/src/parsers/js/flow.js
@@ -9,6 +9,7 @@ export const defaultOptions = {
   esproposal_export_star_as: true,
   esproposal_optional_chaining: true,
   esproposal_nullish_coalescing: true,
+  tokens: false,
   types: true,
 };
 export const parserSettingsConfiguration = {
@@ -19,6 +20,7 @@ export const parserSettingsConfiguration = {
     'esproposal_export_star_as',
     'esproposal_optional_chaining',
     'esproposal_nullish_coalescing',
+    'tokens',
     'types',
   ],
 };


### PR DESCRIPTION
This makes it possible to see the individual tokens generated by the Flow and Babel parsers. Highlighting even works out of the box since tokens have the same location schema as nodes.

A similar capability can probably be added to some of the other parsers - I'm just less familiar with their APIs and I've needed these two in particular.