### PR TITLE
Add support BoundEvent for angular template parser

### DIFF
--- a/website/src/parsers/html/angular.js
+++ b/website/src/parsers/html/angular.js
@@ -97,7 +97,8 @@ function fixSpan(ast, code) {
   function getBaseStart(parent) {
     const nodeName = getNodeName(parent);
     switch (nodeName) {
-      case 'BoundAttribute': {
+      case 'BoundAttribute':
+      case 'BoundEvent': {
         let offset = parent.sourceSpan.start.offset;
         while (code[offset++] !== '=');
         if (code[offset] === "'" || code[offset] === '"') offset++;


### PR DESCRIPTION
Output event not parsed - `Unexpected node BoundEvent`
```html
<!DOCTYPE html>
<html>

<body>
    <h1>My First Heading {{param.name}} </h1>
    <p>My first paragraph.</p>
     <!-- click event -->
    <button (click)="s()"></button>
</body>

</html>
```

after change:
![boundevent](https://user-images.githubusercontent.com/16316579/53635002-df0e6180-3c2c-11e9-8977-929120b23ce0.png)
