### PR TITLE
Add ecmaVersion and sourceType options to typescript-eslint-parser

### DIFF
--- a/website/src/parsers/js/typescript-eslint-parser.js
+++ b/website/src/parsers/js/typescript-eslint-parser.js
@@ -27,6 +27,8 @@ export default {
       tokens: false,
       comment: false,
       useJSXTextNode: false,
+      ecmaVersion: 6,
+      sourceType: 'module',
 
       ecmaFeatures: {
         jsx: true,
@@ -37,6 +39,8 @@ export default {
   _getSettingsConfiguration(defaultOptions) {
     return {
       fields: [
+        ['ecmaVersion', [3, 5, 6, 7, 8, 9], value => Number(value)],
+        ['sourceType', ['script', 'module']],
         'range',
         'loc',
         'tokens',


### PR DESCRIPTION
Fixes https://github.com/fkling/astexplorer/issues/379

The default values are of course debatable...