### PR TITLE
Remove unnecessary getNodeName overrides

### DIFF
--- a/website/src/parsers/css/csstree.js
+++ b/website/src/parsers/css/csstree.js
@@ -22,10 +22,6 @@ export default {
     }));
   },
 
-  getNodeName(node) {
-    return node.type;
-  },
-
   nodeToRange({ loc }) {
     if (loc && loc.start && loc.end) {
       return [loc.start.offset, loc.end.offset];

--- a/website/src/parsers/glsl/glsl-parser.js
+++ b/website/src/parsers/glsl/glsl-parser.js
@@ -57,10 +57,6 @@ export default {
     }
   },
 
-  getNodeName(node) {
-    return node.type;
-  },
-
   opensByDefault(node, key) {
     return key === 'children' && node.type === '(program)';
   },

--- a/website/src/parsers/graphviz/redot.js
+++ b/website/src/parsers/graphviz/redot.js
@@ -26,10 +26,6 @@ export default {
     }
   },
 
-  getNodeName(node) {
-    return node.type;
-  },
-
   opensByDefault(node, key) {
     return key === 'children';
   },

--- a/website/src/parsers/icu/intl-messageformat-parser.js
+++ b/website/src/parsers/icu/intl-messageformat-parser.js
@@ -20,10 +20,6 @@ export default {
     return parser.parse(code);
   },
 
-  getNodeName(node) {
-    return node.type;
-  },
-
   nodeToRange({ location }) {
     if (location && location.start && location.end) {
       return [location.start.offset, location.end.offset];

--- a/website/src/parsers/json/json-to-ast.js
+++ b/website/src/parsers/json/json-to-ast.js
@@ -20,10 +20,6 @@ export default {
     return jsonToAst(code);
   },
 
-  getNodeName(node) {
-    return node.type;
-  },
-
   nodeToRange({loc}) {
     if (loc) {
       return [

--- a/website/src/parsers/markdown/remark.js
+++ b/website/src/parsers/markdown/remark.js
@@ -29,10 +29,6 @@ export default {
     }
   },
 
-  getNodeName(node) {
-    return node.type;
-  },
-
   opensByDefault(node, key) {
     return key === 'children';
   },

--- a/website/src/parsers/mdx/mdxhast.js
+++ b/website/src/parsers/mdx/mdxhast.js
@@ -46,10 +46,6 @@ export default {
     }
   },
 
-  getNodeName(node) {
-    return node.type;
-  },
-
   opensByDefault(node, key) {
     return key === 'children';
   },

--- a/website/src/parsers/regexp/regexp-tree.js
+++ b/website/src/parsers/regexp/regexp-tree.js
@@ -32,10 +32,6 @@ export default {
     }
   },
 
-  getNodeName(node) {
-    return node.type;
-  },
-
   opensByDefault(node, key) {
     return (
       node.type === 'RegExp' ||

--- a/website/src/parsers/scala/scalameta.js
+++ b/website/src/parsers/scala/scalameta.js
@@ -49,10 +49,6 @@ export default {
     }
   },
 
-  getNodeName(node) {
-    return node.type;
-  },
-
   opensByDefault(node, key) {
     return node.type === 'Program'
       || key === 'body'

--- a/website/src/parsers/sql/sqlite-parser.js
+++ b/website/src/parsers/sql/sqlite-parser.js
@@ -19,10 +19,6 @@ export default {
     return sqliteParser(code);
   },
 
-  getNodeName(node) {
-    return node.type;
-  },
-
   opensByDefault(node, key) {
     return key === 'statement';
   },

--- a/website/src/parsers/wat/wat-parser.js
+++ b/website/src/parsers/wat/wat-parser.js
@@ -22,10 +22,6 @@ export default {
     return [loc.start, loc.end].map(pos => this.getOffset(pos));
   },
 
-  getNodeName(node) {
-    return node.type;
-  },
-
   loadParser(callback) {
     require(['@webassemblyjs/wast-parser'], function(parser) {
       callback(parser);

--- a/website/src/parsers/yaml/yaml.js
+++ b/website/src/parsers/yaml/yaml.js
@@ -31,10 +31,6 @@ export default {
     }
   },
 
-  getNodeName(node) {
-    return node.type;
-  },
-
   parse({ parseAllDocuments }, code, options) {
     return parseAllDocuments(code, options);
   },


### PR DESCRIPTION
All of these have exactly same implementations as the base one and only make it harder to find real custom overrides.