### PR TITLE
Fix Vue implementation of getNodeName

### DIFF
--- a/website/src/parsers/html/vue.js
+++ b/website/src/parsers/html/vue.js
@@ -31,11 +31,7 @@ export default {
   },
 
   getNodeName(node) {
-    let nodeName = node.tag;
-    if (nodeName && node.name) {
-      nodeName += `(${node.name})`;
-    }
-    return nodeName;
+    return node.tag;
   },
 
   getDefaultOptions() {


### PR DESCRIPTION
It looks like a copy-paste from htmlparser2, despite the Vue parser not having the extra `name` property.