### PR TITLE
Properly hide type keys in different parsers

### DIFF
--- a/website/src/components/visualization/tree/Element.js
+++ b/website/src/components/visualization/tree/Element.js
@@ -146,7 +146,7 @@ let Element = class extends React.Component {
       .filter(({value}) => !hideFunctions || typeof value !== 'function')
       .filter(({value}) => !hideEmptyKeys || value != null)
       .filter(({key}) => !hideLocationData || !parser.locationProps.has(key))
-      .filter(({key}) => !hideTypeKeys || key !== 'type');
+      .filter(({key}) => !hideTypeKeys || !parser.typeProps.has(key));
   }
 
   _execFunction() {

--- a/website/src/parsers/css/cssom.js
+++ b/website/src/parsers/css/cssom.js
@@ -11,6 +11,7 @@ export default {
   version: pkg.version,
   homepage: pkg.homepage || 'https://github.com/NV/CSSOM',
   locationProps: new Set(['__starts', '__ends']),
+  typeProps: new Set(),
 
   loadParser(callback) {
     require(['cssom/lib/parse'], callback);

--- a/website/src/parsers/graphql/graphql-js.js
+++ b/website/src/parsers/graphql/graphql-js.js
@@ -11,6 +11,7 @@ export default {
   version: pkg.version,
   homepage: pkg.homepage,
   locationProps: new Set(['loc']),
+  typeProps: new Set(['kind']),
 
   loadParser(callback) {
     require(['graphql/language'], ({ parse }) => {

--- a/website/src/parsers/html/angular.js
+++ b/website/src/parsers/html/angular.js
@@ -16,6 +16,7 @@ export default {
     'startSourceSpan',
     'endSourceSpan',
   ]),
+  typeProps: new Set(['name']),
 
   loadParser(callback) {
     require(['@angular/compiler'], callback);

--- a/website/src/parsers/html/htmlparser2.js
+++ b/website/src/parsers/html/htmlparser2.js
@@ -11,6 +11,7 @@ export default {
   version: pkg.version,
   homepage: pkg.homepage || 'https://github.com/fb55/htmlparser2',
   locationProps: new Set(['startIndex']),
+  typeProps: new Set(['type', 'name']),
 
   loadParser(callback) {
     require(['htmlparser2/lib/Parser', 'domhandler'], (Parser, DomHandler) => {

--- a/website/src/parsers/html/parse5.js
+++ b/website/src/parsers/html/parse5.js
@@ -11,6 +11,7 @@ export default {
   version: pkg.version,
   homepage: pkg.homepage,
   locationProps: new Set(['sourceCodeLocation']),
+  typeProps: new Set(['type', 'name', 'nodeName', 'tagName']),
 
   loadParser(callback) {
     require([

--- a/website/src/parsers/html/vue.js
+++ b/website/src/parsers/html/vue.js
@@ -11,6 +11,7 @@ export default {
   version: pkg.version,
   homepage: pkg.homepage,
   locationProps: new Set(['start', 'end']),
+  typeProps: new Set(['tag']),
 
   loadParser(callback) {
     require(['vue-template-compiler/browser'], callback);

--- a/website/src/parsers/js/typescript.js
+++ b/website/src/parsers/js/typescript.js
@@ -15,6 +15,7 @@ export default {
   version: pkg.version,
   homepage: pkg.homepage,
   locationProps: new Set(['pos', 'end']),
+  typeProps: new Set(['kind']),
 
   loadParser(callback) {
     require(['typescript'], _ts => {
@@ -89,7 +90,6 @@ export default {
   },
 
   _ignoredProperties: new Set([
-    'constructor',
     'parent',
   ]),
 

--- a/website/src/parsers/js/uglify.js
+++ b/website/src/parsers/js/uglify.js
@@ -12,6 +12,7 @@ export default {
   version: pkg.version,
   homepage: pkg.homepage,
   locationProps: new Set(['start', 'end']),
+  typeProps: new Set(['TYPE']),
 
   loadParser(callback) {
     require([

--- a/website/src/parsers/php/php-parser.js
+++ b/website/src/parsers/php/php-parser.js
@@ -20,6 +20,7 @@ export default {
   version: pkg.version,
   homepage: pkg.homepage,
   locationProps: new Set(['loc']),
+  typeProps: new Set(['kind']),
 
   loadParser(callback) {
     require(['php-parser'], callback);

--- a/website/src/parsers/utils/defaultParserInterface.js
+++ b/website/src/parsers/utils/defaultParserInterface.js
@@ -51,6 +51,12 @@ export default {
   locationProps: new Set(),
 
   /**
+   * Those properties of an AST node (object) that provide node name
+   * so that they can be hidden in the UI if the option is selected.
+   */
+  typeProps: new Set(['type']),
+
+  /**
    * Whether or not the provided node should be automatically expanded.
    */
   opensByDefault(_node, _key) {

--- a/website/src/parsers/webidl/webidl2.js
+++ b/website/src/parsers/webidl/webidl2.js
@@ -10,6 +10,7 @@ export default {
   displayName: ID,
   version: pkg.version,
   homepage: pkg.homepage || 'https://github.com/w3c/webidl2.js',
+  typeProps: new Set(['name', 'type', 'idlType', 'escapedName']),
 
   getNodeName(node) {
     if (node.name) {

--- a/website/src/parsers/yaml/yaml-ast-parser.js
+++ b/website/src/parsers/yaml/yaml-ast-parser.js
@@ -12,8 +12,9 @@ export default {
   version: pkg.version,
   homepage: pkg.homepage || 'https://www.npmjs.com/package/yaml-ast-parser',
 
-  _ignoredProperties: new Set(['parent', 'errors', 'kind']),
+  _ignoredProperties: new Set(['parent', 'errors']),
   locationProps: new Set(['startPosition', 'endPosition']),
+  typeProps: new Set(['kind']),
 
   nodeToRange(node) {
     if (typeof node.startPosition === 'number') {


### PR DESCRIPTION
Initially the checkbox was implemented only with a hardcoded `type` key in mind despite various parsers using different properties for the `getNodeName`, which resulted in a checkbox not having any effect for these parsers.

This adds a new property `typeKeys: Set<string>` that can be used on parsers with custom `getNodeName` to override set of keys that should be hidden when the checkbox is enabled.