### PR TITLE
Introducing TreeAdapter

### DIFF
--- a/website/src/components/ASTOutput.js
+++ b/website/src/components/ASTOutput.js
@@ -37,7 +37,7 @@ export default function ASTOutput({parser, parseResult={}, cursor=null}) {
   } else if (ast) {
     output = React.createElement(
       visualizations[selectedOutput],
-      {parseResult, focusPath, cursor}
+      {parseResult, focusPath}
     );
   }
 

--- a/website/src/components/ASTOutput.js
+++ b/website/src/components/ASTOutput.js
@@ -37,7 +37,7 @@ export default function ASTOutput({parser, parseResult={}, cursor=null}) {
   } else if (ast) {
     output = React.createElement(
       visualizations[selectedOutput],
-      {ast, focusPath, parser}
+      {parseResult, focusPath, cursor}
     );
   }
 

--- a/website/src/components/visualization/JSON.js
+++ b/website/src/components/visualization/JSON.js
@@ -4,20 +4,15 @@ import React from 'react';
 
 import stringify from 'json-stringify-safe';
 
-export default class JSON extends React.Component {
-  render() {
-    return (
-      <JSONEditor
-        className="container"
-        value={stringify(this.props.ast, null, 2)}
-      />
-    );
-  }
+export default function JSON({parseResult}) {
+  return (
+    <JSONEditor
+      className="container"
+      value={stringify(parseResult.ast, null, 2)}
+    />
+  );
 }
 
 JSON.propTypes = {
-  ast: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.object,
-  ]),
+  parseResult: PropTypes.object,
 };

--- a/website/src/components/visualization/Tree.js
+++ b/website/src/components/visualization/Tree.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import PubSub from 'pubsub-js';
 import {logEvent} from '../../utils/logger';
+import {treeAdapterFromParseResult} from '../../core/TreeAdapter.js';
 
 import './css/tree.css'
 
@@ -47,7 +48,7 @@ function makeCheckbox(name, settings, updateSettings) {
   );
 }
 
-export default function Tree({focusPath, ast, parser}) {
+export default function Tree({focusPath, parseResult, cursor}) {
   const [settings, updateSettings] = useReducer(reducer, null, initSettings);
 
   return (
@@ -81,9 +82,9 @@ export default function Tree({focusPath, ast, parser}) {
       <ul onMouseLeave={() => {PubSub.publish('CLEAR_HIGHLIGHT');}}>
         <Element
           focusPath={focusPath}
-          value={ast}
+          value={parseResult.ast}
           level={0}
-          parser={parser}
+          treeAdapter={treeAdapterFromParseResult(parseResult, settings)}
           settings={settings}
         />
       </ul>
@@ -93,9 +94,7 @@ export default function Tree({focusPath, ast, parser}) {
 
 Tree.propTypes = {
   focusPath: PropTypes.array,
-  ast: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.object,
-  ]),
+  parseResult: PropTypes.object,
   parser: PropTypes.object,
+  cursor: PropTypes.number,
 };

--- a/website/src/components/visualization/css/tree.css
+++ b/website/src/components/visualization/css/tree.css
@@ -8,7 +8,7 @@
   flex-shrink: 0;
 }
 
-.tree-visualization > .toolbar > label {
+.tree-visualization > .toolbar label {
   cursor: pointer;
   margin-right: 5px;
   -webkit-touch-callout: none;

--- a/website/src/core/ParseResult.js
+++ b/website/src/core/ParseResult.js
@@ -1,0 +1,32 @@
+/**
+ * Describes the result of a parse process. Only exists here for documentation
+ * purposes.
+ */
+// eslint-disable-next-line no-unused-vars
+const ParseResult = {
+  /**
+   * The generated AST
+   */
+  ast: 'any',
+
+  /**
+   * An error object, if parsing resulted in an error
+   */
+  error: 'Object',
+
+  /**
+   * How long it took to generate the AST
+   */
+  time: 'number',
+
+  treeAdapter: {
+    /**
+     * The type of the adapter to use, as defined in TreeAdapters.js
+     */
+    type: 'string',
+    /**
+     * Override the default options with these values
+     */
+    options: 'Object',
+  },
+};

--- a/website/src/core/TreeAdapter.js
+++ b/website/src/core/TreeAdapter.js
@@ -1,0 +1,185 @@
+/**
+ * Configurable base class for all tree traversal.
+ */
+class TreeAdapter {
+
+  constructor(adapterOptions, walkOptions) {
+    this._ranges = new WeakMap();
+    this._walkOptions = walkOptions;
+    this._adapterOptions = adapterOptions;
+  }
+
+  /**
+   * Used by the UI
+
+  /**
+   * A more or less human readable name of the node.
+   */
+  getNodeName(node) {
+    return this._adapterOptions.nodeToName(node);
+  }
+
+  /**
+   * The start and end indicies of the node in the source text. The return value
+   * is an array of form `[start, end]`. This is used for highlighting source
+   * text and focusing nodes in the tree.
+   */
+  getRange(node) {
+    if (!(node && typeof node === 'object')) {
+      return null;
+    }
+
+    if (this._ranges.has(node)) {
+      return this._ranges.get(node);
+    }
+    const {nodeToRange} = this._adapterOptions;
+    let range = nodeToRange(node);
+    if (!range) {
+      // If the node doesn't have location data itself, try to derive it from
+      // its first and last child.
+      let first, last;
+      const iterator = this.walkNode(node);
+      let next = iterator.next();
+      if (!next.done) {
+        first = last = next.value && next.value.value;
+      }
+      while (!(next = iterator.next()).done) {
+        last = next.value && next.value.value;
+      }
+      const rangeFirst = first && nodeToRange(first);
+      const rangeLast = last && nodeToRange(last);
+      if (rangeFirst && rangeLast) {
+        range = [rangeFirst[0], rangeLast[1]];
+      }
+    }
+    this._ranges.set(node, range);
+    return range;
+  }
+
+  isInRange(node, position) {
+    const range = this.getRange(node);
+    if (!range) {
+      return false;
+    }
+    return range[0] <= position && position <= range[1];
+  }
+
+  hasChildrenInRange(node) {
+    if (!this.isInRange(node)) {
+      return false;
+    }
+    for (const {value: child} of this.walkNode(node)) {
+      if (this.isInRange(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Whether or not the provided node should be automatically expanded.
+   */
+  opensByDefault(node, key) {
+    return this._adapterOptions.openByDefault(node, key);
+  }
+
+  isArray(node) {
+    return Array.isArray(node);
+  }
+
+  isObject(node) {
+    return Boolean(node) && typeof node === 'object' && !this.isArray(node);
+  }
+
+  /**
+   * A generator to iterate over each "property" of the node.
+   * Overwriting _walkNode allows a parser to expose information from a node if
+   * the node is not implemented as plain JavaScript object.
+   */
+  *walkNode(node) {
+    const walkOptions = this._walkOptions;
+    for (const result of this._walkNode(node)) {
+      if (
+        this._adapterOptions.ignoredKeys.has(result.key) ||
+        walkOptions.hideFunctions && typeof result.value === 'function' ||
+        walkOptions.hideEmptyKeys && result.value == null ||
+        walkOptions.hideLocationData && this._adapterOptions.locationKeys.has(result.key) ||
+        walkOptions.hideTypeKeys && result.key === 'type'
+      ) {
+        continue;
+      }
+      yield result;
+    }
+  }
+
+  *_walkNode(node) {
+    yield* this._adapterOptions.walkNode(node);
+  }
+
+}
+
+const TreeAdapterConfigs = {
+  default: {
+    ignoredKeys: new Set(),
+    locationKeys: new Set(),
+    openByDefault: () => false,
+    nodeToRange: () => null,
+    nodeToName: () => { throw new Error('nodeToName must be passed');},
+    walkNode: () => { throw new Error('walkNode must be passed');},
+  },
+
+  estree: {
+    ignoredKeys: new Set(),
+    locationKeys: new Set(['range', 'loc', 'start', 'end']),
+    openByDefaultNodes: new Set(['Program']),
+    openByDefaultKeys: new Set([
+      'body',
+      'elements', // array literals
+      'declarations', // variable declaration
+      'expression', // expression statements
+    ]),
+    openByDefault(node, key) {
+      return node && this.openByDefaultNodes.has(node.type) ||
+        this.openByDefaultKeys.has(key);
+    },
+    nodeToRange(node) {
+      if (node.range) {
+        return node.range;
+      }
+      if (typeof node.start === 'number' && typeof node.end === 'number') {
+        return [node.start, node.end];
+      }
+      return null;
+    },
+    nodeToName(node) {
+      return node.type;
+    },
+    *walkNode(node) {
+      for (let prop in node) {
+        yield {
+          value: node[prop],
+          key: prop,
+          computed: false,
+        }
+      }
+    },
+  },
+};
+
+function createTreeAdapter(type, adapterOptions, walkOptions) {
+  if (TreeAdapterConfigs[type] == null) {
+    throw new Error(`Unknown tree adapter type "${type}"`);
+  }
+  return new TreeAdapter(
+    Object.assign({}, TreeAdapterConfigs[type], adapterOptions),
+    walkOptions,
+  );
+}
+
+export function treeAdapterFromParseResult({treeAdapter}, walkOptions) {
+  return createTreeAdapter(
+    treeAdapter.type,
+    treeAdapter.options,
+    walkOptions
+  );
+}

--- a/website/src/parsers/js/utils/defaultESTreeParserInterface.js
+++ b/website/src/parsers/js/utils/defaultESTreeParserInterface.js
@@ -5,7 +5,7 @@ export default {
 
   opensByDefault(node, key) {
     return (
-      node.type === 'Program' ||
+      Boolean(node) && node.type === 'Program' ||
       key === 'body' ||
       key === 'elements' || // array literals
       key === 'declarations' || // variable declaration

--- a/website/src/store/parserMiddleware.js
+++ b/website/src/store/parserMiddleware.js
@@ -1,4 +1,5 @@
 import {getParser, getParserSettings, getCode} from './selectors';
+import {ignoreKeysFilter, locationInformationFilter, functionFilter, emptyKeysFilter, typeKeysFilter} from '../core/TreeAdapter.js';
 
 function parse(parser, code, parserSettings) {
   if (!parser._promise) {
@@ -46,12 +47,17 @@ export default store => next => action => {
         const treeAdapter = {
           type: 'default',
           options: {
-            ignoredKeys: newParser._ignoredProperties,
-            locationKeys: newParser.locationProps,
             openByDefault: (newParser.opensByDefault || (() => false)).bind(newParser),
             nodeToRange: newParser.nodeToRange.bind(newParser),
             nodeToName: newParser.getNodeName.bind(newParser),
             walkNode: newParser.forEachProperty.bind(newParser),
+            filters: [
+              ignoreKeysFilter(newParser._ignoredProperties),
+              functionFilter(),
+              emptyKeysFilter(),
+              locationInformationFilter(newParser.locationProps),
+              typeKeysFilter(newParser.typeProps),
+            ],
           },
         };
         next({

--- a/website/src/store/parserMiddleware.js
+++ b/website/src/store/parserMiddleware.js
@@ -42,12 +42,25 @@ export default store => next => action => {
         ) {
           return;
         }
+        // Temporary adapter for parsers that haven't been migrated yet.
+        const treeAdapter = {
+          type: 'default',
+          options: {
+            ignoredKeys: newParser._ignoredProperties,
+            locationKeys: newParser.locationProps,
+            openByDefault: (newParser.opensByDefault || (() => false)).bind(newParser),
+            nodeToRange: newParser.nodeToRange.bind(newParser),
+            nodeToName: newParser.getNodeName.bind(newParser),
+            walkNode: newParser.forEachProperty.bind(newParser),
+          },
+        };
         next({
           type: 'SET_PARSE_RESULT',
           result: {
             time: Date.now() - start,
             ast: ast,
             error: null,
+            treeAdapter,
           },
         });
       },
@@ -58,6 +71,7 @@ export default store => next => action => {
           result: {
             time: null,
             ast: null,
+            treeAdapter: null,
             error,
           },
         });


### PR DESCRIPTION
Note: I'm going to merge this immediately because it fixes #398, but this can serve as a place to discuss the overall new approach.

---

A design flaw of the current implementation is that a parser adapter/wrapper (the files in `src/parser/`) serves multiple purposes, one of them being to encapsulate how astexplorer can interact with the resulting AST (e.g. get the node of name, it's children, etc). This tight coupling makes it difficult to improve the logic around parser.

As a first step this commit introduces a "tree adapter" which encapsulates all the AST interfacing logic. Eventually, parser will return a tree adapter configuration from their parse method. The interface / configuration options are subject to change as the existing parser are migrated over. For now the parser middleware takes care of creating the tree adapter.

This also allows us to reduce the dependency of UI components on the parser object.