### PR TITLE
flow 0.103

### DIFF
--- a/website/src/parsers/js/flow.js
+++ b/website/src/parsers/js/flow.js
@@ -3,6 +3,7 @@ import pkg from 'flow-parser/package.json';
 
 const ID = 'flow';
 export const defaultOptions = {
+  enums: false,
   esproposal_class_instance_fields: true,
   esproposal_class_static_fields: true,
   esproposal_decorators: true,
@@ -14,6 +15,7 @@ export const defaultOptions = {
 };
 export const parserSettingsConfiguration = {
   fields: [
+    'enums',
     'esproposal_class_instance_fields',
     'esproposal_class_static_fields',
     'esproposal_decorators',

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4442,10 +4442,10 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
-flow-parser@0.*, flow-parser@^0.94.0:
-  version "0.94.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.94.0.tgz#bae54cd3365c800dbe8062f82611a85c5ce872f4"
-  integrity sha512-zKVDm2rq9Z4GZDNT2GjEtoSat4NW/aZBkHsXs/XNnf39VOAzB0ufkxpuS6XgwuEaMUnhZEAA0gk7ASGxP/TQCQ==
+flow-parser@0.*, flow-parser@^0.103.0:
+  version "0.103.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.103.0.tgz#7afc50498e543856e090c5b5d924ae60e7c1add6"
+  integrity sha512-H5UaM7mCzrssGa/HiPcr+oWBKosZTI7AlRk3jCEznBC786mdWIrTRjjGIAlRwuTVwT6SlPzV0M7kM6e3GGIQYA==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
Update to Flow 0.103. Add option (default off) to parse experimental enums. 

Tested through `yarn run build && yarn run start`, checking out website locally