### PR TITLE
Add lucene query syntax AST parser

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -100,6 +100,7 @@
     "json-to-ast": "^2.1.0",
     "lodash.isequal": "^4.5.0",
     "luaparse": "^0.2.1",
+    "lucene": "^2.1.0",
     "parse5": "^5.1.0",
     "parse5-htmlparser2-tree-adapter": "^5.1.0",
     "php-parser": "^3.0.0-prerelease.8",

--- a/website/src/parsers/lucene/codeExample.txt
+++ b/website/src/parsers/lucene/codeExample.txt
@@ -1,0 +1,1 @@
+name:frank OR job:engineer AND food:/marshmal+ows/

--- a/website/src/parsers/lucene/index.js
+++ b/website/src/parsers/lucene/index.js
@@ -1,0 +1,4 @@
+export const id = 'lucene';
+export const displayName = 'Lucene';
+export const mimeTypes = [''];
+export const fileExtension = 'lucene';

--- a/website/src/parsers/lucene/lucene.js
+++ b/website/src/parsers/lucene/lucene.js
@@ -1,0 +1,51 @@
+import defaultParserInterface from '../utils/defaultParserInterface';
+import pkg from 'lucene/package.json';
+
+const ID = 'lucene';
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: ID,
+  version: pkg.version,
+  homepage: pkg.homepage,
+  locationProps: new Set(['fieldLocation', 'termLocation', 'location']),
+
+  loadParser(callback) {
+    require(['lucene'], callback);
+  },
+
+  parse({parse}, code) {
+    return parse(code);
+  },
+
+  nodeToRange(node) {
+    let start = [];
+    let end = [];
+
+    if (node.location) {
+      start.push(node.location.start.offset);
+      end.push(node.location.end.offset);
+    }
+    if (node.fieldLocation) {
+      start.push(node.fieldLocation.start.offset);
+      end.push(node.fieldLocation.end.offset);
+    }
+    if (node.termLocation) {
+      start.push(node.termLocation.start.offset);
+      end.push(node.termLocation.end.offset);
+    }
+
+    if (start.length === 0 || end.length === 0) {
+      return;
+    }
+
+    return [start.reduce((a, b) => Math.min(a, b)), end.reduce((a, b) => Math.max(a, b))];
+  },
+
+  getDefaultOptions() {
+    return {};
+  },
+
+};

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -9744,3 +9744,8 @@ zwitch@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.3.tgz#159fae4b3f737db1e42bf321d3423e4c96688a18"
   integrity sha512-aynRpmJDw7JIq6X4NDWJoiK1yVSiG57ArWSg4HLC1SFupX5/bo0Cf4jpX0ifwuzBfxpYBuNSyvMlWNNRuy3cVA==
+
+lucene@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/lucene/-/lucene-2.1.0.tgz#0883920a7c58523300e157c05123b6e6a7535235"
+  integrity sha512-uvBFSw4BOPWun5WCqpRmKhwLq8DOsts2UWgpOnKlwONlprmv/Lh116RCfoWFMLa4HekOkoCiyEQGMrXgQqyj5g==


### PR DESCRIPTION
# Why

The [lucene query syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html)
is widely spread across tools and databases, e.g. Elasticsearch and solr..
It is also commonly used in products to enable rich search capabilities, e.g.
Instana, Slack, LogDNA and more.

# What

Add a new parser to the website to parse lucene to AST and to provide
node highlighting support.

# Screenshot

![image](https://user-images.githubusercontent.com/596443/61954743-c75bbf00-afb9-11e9-949a-a4b2153e7705.png)

# References

Fixes https://github.com/bripkens/lucene/issues/25