### PR TITLE
Fix overflowing toolbar menu

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -158,6 +158,8 @@ html {
   border: 1px solid #ddd;
   border-top: none;
   min-width: 100%;
+  max-height: calc(80vh - 32px);
+  overflow: auto;
 }
 
 #Toolbar .menuButton ul li {


### PR DESCRIPTION
This PR fixes the overflowing toolbar menu on smaller screens.

Before: 
![image](https://user-images.githubusercontent.com/37990858/64343058-c55c3580-d026-11e9-8081-e209d4330398.png)

After: 
![image](https://user-images.githubusercontent.com/37990858/64343111-e0c74080-d026-11e9-82c0-5f464ad2e86b.png)

