### PR TITLE
feature: add regjsparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The AST explorer provides following code parsers:
   - [php-parser][]
 - Regular Expressions:
   - [regexp-tree][]
+  - [regjsparser][]
 - Scala
   - [Scalameta][]
 - Solidity:
@@ -148,6 +149,7 @@ node.
 [redot]: https://github.com/redotjs/redot
 [remark]: https://github.com/remarkjs/remark
 [regexp-tree]: https://github.com/DmitrySoshnikov/regexp-tree
+[regjsparser]: https://github.com/jviereck/regjsparser
 [php-parser]: https://github.com/glayzzle/php-parser
 [glimmer]: https://github.com/glimmerjs/glimmer-vm
 [handlebars]: http://handlebarsjs.com/

--- a/website/package.json
+++ b/website/package.json
@@ -125,6 +125,7 @@
     "redux-batched-actions": "^0.2.0",
     "redux-saga": "^0.15.3",
     "regexp-tree": "^0.1.5",
+    "regjsparser": "^0.6.0",
     "remark": "^11.0.1",
     "reselect": "^4.0.0",
     "scalameta-parsers": "^4.2.1",

--- a/website/src/parsers/regexp/regjsparser.js
+++ b/website/src/parsers/regexp/regjsparser.js
@@ -33,13 +33,7 @@ export default {
     }
     var flags = code.slice(lastSlash + 1);
     var pattern = code.slice(firstSlash + 1, lastSlash);
-    try {
-      return regjsparser.parse(pattern, flags, options);
-    } catch (err) {
-      err.message.replace("\n", "<br>");
-      throw err;
-    }
-
+    return regjsparser.parse(pattern, flags, options);
   },
 
   nodeToRange(node) {

--- a/website/src/parsers/regexp/regjsparser.js
+++ b/website/src/parsers/regexp/regjsparser.js
@@ -1,0 +1,61 @@
+import defaultParserInterface from '../utils/defaultParserInterface';
+import pkg from 'regjsparser/package.json';
+
+const ID = 'regjsparser';
+
+export const defaultOptions = {
+  unicodePropertyEscape: true,
+  namedGroups: true,
+  lookbehind: true,
+};
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: ID,
+  version: pkg.version,
+  homepage: pkg.homepage,
+  locationProps: new Set(['range']),
+
+  loadParser(callback) {
+    require(['regjsparser'], callback);
+  },
+
+  parse(regjsparser, code, options) {
+    if (Object.keys(options).length === 0) {
+      options = this.getDefaultOptions();
+    }
+    var firstSlash = code.indexOf('/');
+    var lastSlash = code.lastIndexOf('/');
+    if (firstSlash !== 0 || lastSlash < 1) {
+      throw new Error('Please wrap the regex pattern by slash `/`, i.e. /foo/');
+    }
+    var flags = code.slice(lastSlash + 1);
+    var pattern = code.slice(firstSlash + 1, lastSlash);
+    try {
+      return regjsparser.parse(pattern, flags, options);
+    } catch (err) {
+      err.message.replace("\n", "<br>");
+      throw err;
+    }
+
+  },
+
+  nodeToRange(node) {
+    if (node.range != null) {
+      return [node.range[0] + 1, node.range[1] + 1];
+    }
+  },
+
+  opensByDefault(node, key) {
+    return (
+        key === 'body'
+    );
+  },
+
+  getDefaultOptions() {
+    return defaultOptions;
+  },
+
+};

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -168,6 +168,7 @@ module.exports = Object.assign({
           path.join(__dirname, 'node_modules', 'redux', 'es'),
           path.join(__dirname, 'node_modules', 'redux-saga', 'es'),
           path.join(__dirname, 'node_modules', 'regexp-tree'),
+          path.join(__dirname, 'node_modules', 'regjsparser'),
           path.join(__dirname, 'node_modules', 'simple-html-tokenizer'),
           path.join(__dirname, 'node_modules', 'symbol-observable', 'es'),
           path.join(__dirname, 'node_modules', 'typescript-eslint-parser'),


### PR DESCRIPTION
In this PR we add regjsparser support to astexplorer.

Background: regjsparser is used by a popular library `regexpu-core`, which transpiles unicode related regular expressions to ES5. `@babel/preset-env` replies on `regexpu-core` for unicode regex features.

When we are investigating babel issues about unsupported regex, I realize it would be convenient to browse the ast generated by regjsparser, isolate the problem and to see if it is on the parser side or the transformer side.