### PR TITLE
Issue #438 - Add typescript as a parser for recast

### DIFF
--- a/website/src/parsers/js/recast.js
+++ b/website/src/parsers/js/recast.js
@@ -68,7 +68,9 @@ export default {
       case 'babel5':
         options.parser = parsers[options.parser];
         break;
-      case 'esprima':
+      case 'typescript':
+        options.parser = require('recast/parsers/typescript')
+        break
       default:
         delete options.parser; // default parser
         break;
@@ -114,7 +116,7 @@ export default {
   _getSettingsConfiguration(defaultOptions) {
     return {
       fields: [
-        ['parser', ['esprima', 'babel5', 'babylon6', 'babylon7', 'flow']],
+        ['parser', ['esprima', 'babel5', 'babylon6', 'babylon7', 'flow', 'typescript']],
         'range',
         'tolerant',
         {


### PR DESCRIPTION
This adds typescript support for recast.

This follows the example given in the recast docs

```javascript
const tsAst = recast.parse(source, {
  parser: require("recast/parsers/typescript")
});
```
https://github.com/benjamn/recast#using-a-different-parser