### PR TITLE
Issue #438 - Add typescript as a parser for recast

### DIFF
--- a/website/src/parsers/js/recast.js
+++ b/website/src/parsers/js/recast.js
@@ -19,8 +19,8 @@ export default {
 
   loadParser(callback) {
     require(
-      ['recast', 'babel5', 'babylon6', 'babylon7', 'flow-parser'],
-      (recast, babelCore, babylon6, babylon7, flow) => {
+      ['recast', 'babel5', 'babylon6', 'babylon7', 'flow-parser', 'recast/parsers/typescript'],
+      (recast, babelCore, babylon6, babylon7, flow, typescript) => {
         callback({
           recast,
           parsers: {
@@ -28,6 +28,7 @@ export default {
             babylon6,
             babylon7,
             flow,
+            typescript,
           },
         });
       }
@@ -68,7 +69,9 @@ export default {
       case 'babel5':
         options.parser = parsers[options.parser];
         break;
-      case 'esprima':
+      case 'typescript':
+        options.parser = parsers.typescript;
+        break
       default:
         delete options.parser; // default parser
         break;
@@ -114,7 +117,7 @@ export default {
   _getSettingsConfiguration(defaultOptions) {
     return {
       fields: [
-        ['parser', ['esprima', 'babel5', 'babylon6', 'babylon7', 'flow']],
+        ['parser', ['esprima', 'babel5', 'babylon6', 'babylon7', 'flow', 'typescript']],
         'range',
         'tolerant',
         {


### PR DESCRIPTION
This adds typescript support for recast.

This follows the example given in the recast docs

```javascript
const tsAst = recast.parse(source, {
  parser: require("recast/parsers/typescript")
});
```
https://github.com/benjamn/recast#using-a-different-parser