### PR TITLE
Disable retainLines in babel7 output

### DIFF
--- a/website/src/parsers/js/transformers/babel7/index.js
+++ b/website/src/parsers/js/transformers/babel7/index.js
@@ -55,7 +55,7 @@ export default {
           'throwExpressions',
         ],
       },
-      retainLines: true,
+      retainLines: false,
       generatorOpts: {
         generator: recast.print,
       },


### PR DESCRIPTION
Using retain lines causes some really ugly printing when the transform replaces nodes. The [https://astexplorer.net/#/gist/cfe3629169c8b47714064648e372c265/cc5b0e00d9dee45a53fc55f280be0cb36d53028b](example) I have on hand has the `you` variable adding several newlines to keep the same sourceline location. The `_template` function which is injected is also really ugly to look at.

Compare that with the output when `retainLines` is set to false (look for the commented out `pre()` block). Babel uses a rudimentary pretty-printer by default.