### PR TITLE
Add solidity-parser-diligence

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -135,6 +135,7 @@
     "scalameta-parsers": "^4.2.1",
     "shift-parser": "^7.0.0",
     "solidity-parser-antlr": "^0.4.0",
+    "solidity-parser-diligence": "^0.4.18",
     "source-map": "^0.6.1",
     "sqlite-parser": "^1.0.0-rc3",
     "svelte": "^3.4.1",

--- a/website/src/parsers/solididy/solidity-parser-diligence.js
+++ b/website/src/parsers/solididy/solidity-parser-diligence.js
@@ -1,0 +1,49 @@
+import pkg from 'solidity-parser-diligence/package.json';
+import defaultParserInterface from '../utils/defaultParserInterface';
+
+const ID = 'solidity-parser-diligence';
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: ID,
+  version: pkg.version,
+  homepage: pkg.homepage || 'https://github.com/consensys/solidity-parser-antlr',
+
+  loadParser(callback) {
+    require(['solidity-parser-diligence'], callback);
+  },
+
+  parse(parser, code, options) {
+    return parser.parse(code, options);
+  },
+
+  opensByDefault(node, key) {
+    return node.type === 'SourceUnit' ||
+      node.type === 'ContractDefinition' ||
+      key === 'children' ||
+      key === 'subNodes' ||
+      key === 'body'
+  },
+
+  getDefaultOptions() {
+    return {
+      range: true,
+      loc: false,
+      tolerant: false,
+    };
+  },
+
+  _getSettingsConfiguration() {
+    return {
+      fields: [
+        'range',
+        'loc',
+        'tolerant',
+      ],
+    };
+  },
+
+};
+

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -9179,6 +9179,11 @@ solidity-parser-antlr@^0.4.0:
   resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.4.11.tgz#af43e1f13b3b88309a875455f5d6e565b05ee5f1"
   integrity sha512-4jtxasNGmyC0midtjH/lTFPZYvTTUMy6agYcF+HoMnzW8+cqo3piFrINb4ZCzpPW+7tTVFCGa5ubP34zOzeuMg==
 
+solidity-parser-diligence@^0.4.18:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/solidity-parser-diligence/-/solidity-parser-diligence-0.4.18.tgz#1ec8c29d320afe048db941828f142dec3e97f657"
+  integrity sha512-mauO/qG2v59W9sOn5TYV2dS7+fvFKqIHwiku+TH82e1Yca4H8s6EDG12ZpXO2cmgLlCKX3FOqqC73aYLB8WwNg==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"


### PR DESCRIPTION
[solidity-parser-diligence](https://github.com/ConsenSys/solidity-parser-antlr) is a fork of solidity-parser-antlr that supports solidity 0.6.x.