### PR TITLE
enable nullishCoalescingOperator for babylon7 by default

### DIFF
--- a/website/src/parsers/js/babylon7.js
+++ b/website/src/parsers/js/babylon7.js
@@ -56,6 +56,7 @@ export const defaultOptions = {
     'jsx',
     'objectRestSpread',
     'dynamicImport',
+    'nullishCoalescingOperator',
     'numericSeparator',
     'optionalChaining',
     'optionalCatchBinding',


### PR DESCRIPTION
I would like to propose enabling `nullishCoalescingOperator` for babylon7 by default, given that it is enabled for `babel-plugin-macros`, `flow` parser. It also works in typescript parser out of the box and it is now works in the [latest chrome and firefox versions](https://caniuse.com/#feat=mdn-javascript_operators_nullish_coalescing). I think it is a good idea for this plugin to be enabled by default.