### PR TITLE
refmt: add 'loc' to locKeys

### DIFF
--- a/website/src/parsers/reason/refmt.js
+++ b/website/src/parsers/reason/refmt.js
@@ -7,6 +7,7 @@ addCodeMirrorMode(CodeMirror);
 
 const ID = 'refmt';
 const locKeys = [
+  'loc',
   'pcd_loc',
   'pcf_loc',
   'pci_loc',


### PR DESCRIPTION
Hi!

Thanks for AST explorer. It's an invaluable tool to develop syntax extensions for OCaml.

This PR adds `loc` to `locKeys` in refmt, which was previously missing. It corresponds to the `'a loc` type of the OCaml AST, which associate a piece of data with a location.

For example, on the OCaml example, selecting "Printf" highlights a node of type `Longident.t Asttypes.loc`. These nodes have a `txt` field and a `loc` field.

<details>
  <summary>Screenshots</summary>

### master

![master](https://user-images.githubusercontent.com/496345/75250750-598aa680-57d9-11ea-9996-e56afa50335f.png)

### fixed version
![fix](https://user-images.githubusercontent.com/496345/75250756-5d1e2d80-57d9-11ea-9af1-72a10ff2b832.png)
</details>

Thanks!