### PR TITLE
Add basic settings drawer

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -509,3 +509,13 @@ body .CodeMirror-Tern-tooltip {
   padding-left: 5px;
   font-size: 12px;
 }
+
+.settings-drawer__expanded {
+  width: 200px;
+  border-right: 1px solid #ddd;
+}
+
+.settings-drawer__collapsed {
+  width: 20px;
+  background-color: #ddd;
+}

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types';
 import PubSub from 'pubsub-js';
 import React from 'react';
 import SettingsDialogContainer from './containers/SettingsDialogContainer';
-import SettingsDrawerContainer from './containers/SettingsDrawerContainer';
 import ShareDialogContainer from './containers/ShareDialogContainer';
 import SplitPane from './components/SplitPane';
 import ToolbarContainer from './containers/ToolbarContainer';
@@ -46,21 +45,18 @@ function App(props) {
         <div id="root">
           <ToolbarContainer />
           <GistBanner />
-          <div style={{display: 'flex', height: '100%'}}>
-            <SettingsDrawerContainer />
+          <SplitPane
+            className="splitpane-content"
+            vertical={true}
+            onResize={resize}>
             <SplitPane
-              className="splitpane-content"
-              vertical={true}
+              className="splitpane"
               onResize={resize}>
-              <SplitPane
-                className="splitpane"
-                onResize={resize}>
-                <CodeEditorContainer />
-                <ASTOutputContainer />
-              </SplitPane>
-              {props.showTransformer ? <TransformerContainer /> : null}
+              <CodeEditorContainer />
+              <ASTOutputContainer />
             </SplitPane>
-          </div>
+            {props.showTransformer ? <TransformerContainer /> : null}
+          </SplitPane>
         </div>
         </PasteDropTargetContainer>
       </div>

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import PubSub from 'pubsub-js';
 import React from 'react';
 import SettingsDialogContainer from './containers/SettingsDialogContainer';
+import SettingsDrawerContainer from './containers/SettingsDrawerContainer';
 import ShareDialogContainer from './containers/ShareDialogContainer';
 import SplitPane from './components/SplitPane';
 import ToolbarContainer from './containers/ToolbarContainer';
@@ -45,18 +46,21 @@ function App(props) {
         <div id="root">
           <ToolbarContainer />
           <GistBanner />
-          <SplitPane
-            className="splitpane-content"
-            vertical={true}
-            onResize={resize}>
+          <div style={{display: 'flex', height: '100%'}}>
+            <SettingsDrawerContainer />
             <SplitPane
-              className="splitpane"
+              className="splitpane-content"
+              vertical={true}
               onResize={resize}>
-              <CodeEditorContainer />
-              <ASTOutputContainer />
+              <SplitPane
+                className="splitpane"
+                onResize={resize}>
+                <CodeEditorContainer />
+                <ASTOutputContainer />
+              </SplitPane>
+              {props.showTransformer ? <TransformerContainer /> : null}
             </SplitPane>
-            {props.showTransformer ? <TransformerContainer /> : null}
-          </SplitPane>
+          </div>
         </div>
         </PasteDropTargetContainer>
       </div>

--- a/website/src/components/SettingsDrawer.js
+++ b/website/src/components/SettingsDrawer.js
@@ -1,5 +1,5 @@
-import PropTypes from "prop-types";
-import React from "react";
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export default class SettingsDrawer extends React.Component {
   constructor(props) {
@@ -19,17 +19,18 @@ export default class SettingsDrawer extends React.Component {
   render() {
     return (
       this.props.isOpen ? 
-        <div className="settings-drawer__expanded">
+        <div className='settings-drawer__expanded'>
           <h3>Settings</h3>
           <button onClick={this._collapse}>Close</button>
         </div>
       : 
-        <div className="settings-drawer__collapsed" onClick={this._expand}></div>
+        <div className='settings-drawer__collapsed' onClick={this._expand}></div>
     );
   }
 }
 
 SettingsDrawer.propTypes = {
-  onWantToClose: PropTypes.func,
-  visible: PropTypes.bool
+  onWantToExpand: PropTypes.func,
+  onWantToCollapse: PropTypes.func,
+  isOpen: PropTypes.bool,
 };

--- a/website/src/components/SettingsDrawer.js
+++ b/website/src/components/SettingsDrawer.js
@@ -1,0 +1,35 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+export default class SettingsDrawer extends React.Component {
+  constructor(props) {
+    super(props);
+    this._expand = this._expand.bind(this);
+    this._collapse = this._collapse.bind(this);
+  }
+
+  _expand() {
+    this.props.onWantToExpand();
+  }
+
+  _collapse() {
+    this.props.onWantToCollapse();
+  }
+
+  render() {
+    return (
+      this.props.isOpen ? 
+        <div className="settings-drawer__expanded">
+          <h3>Settings</h3>
+          <button onClick={this._collapse}>Close</button>
+        </div>
+      : 
+        <div className="settings-drawer__collapsed" onClick={this._expand}></div>
+    );
+  }
+}
+
+SettingsDrawer.propTypes = {
+  onWantToClose: PropTypes.func,
+  visible: PropTypes.bool
+};

--- a/website/src/containers/SettingsDrawerContainer.js
+++ b/website/src/containers/SettingsDrawerContainer.js
@@ -1,22 +1,22 @@
-import { connect } from "react-redux";
-import { expandSettingsDrawer, collapseSettingsDrawer } from "../store/actions";
-import { showSettingsDrawer } from "../store/selectors";
-import SettingsDrawer from "../components/SettingsDrawer";
+import { connect } from 'react-redux';
+import { expandSettingsDrawer, collapseSettingsDrawer } from '../store/actions';
+import { showSettingsDrawer } from '../store/selectors';
+import SettingsDrawer from '../components/SettingsDrawer';
 
 function mapStateToProps(state) {
   return {
-    isOpen: showSettingsDrawer(state)
+    isOpen: showSettingsDrawer(state),
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onWantToExpand: () => dispatch(expandSettingsDrawer()),
-    onWantToCollapse: () => dispatch(collapseSettingsDrawer())
+    onWantToCollapse: () => dispatch(collapseSettingsDrawer()),
   };
 }
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(SettingsDrawer);

--- a/website/src/containers/SettingsDrawerContainer.js
+++ b/website/src/containers/SettingsDrawerContainer.js
@@ -1,0 +1,22 @@
+import { connect } from "react-redux";
+import { expandSettingsDrawer, collapseSettingsDrawer } from "../store/actions";
+import { showSettingsDrawer } from "../store/selectors";
+import SettingsDrawer from "../components/SettingsDrawer";
+
+function mapStateToProps(state) {
+  return {
+    isOpen: showSettingsDrawer(state)
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onWantToExpand: () => dispatch(expandSettingsDrawer()),
+    onWantToCollapse: () => dispatch(collapseSettingsDrawer())
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(SettingsDrawer);

--- a/website/src/store/actions.js
+++ b/website/src/store/actions.js
@@ -14,6 +14,8 @@ export const SET_PARSE_RESULT = 'SET_PARSE_RESULT';
 export const SET_SNIPPET = 'SET_SNIPPET';
 export const OPEN_SETTINGS_DIALOG = 'OPEN_SETTINGS_DIALOG';
 export const CLOSE_SETTINGS_DIALOG = 'CLOSE_SETTINGS_DIALOG';
+export const EXPAND_SETTINGS_DRAWER = 'EXPAND_SETTINGS_DRAWER';
+export const COLLAPSE_SETTINGS_DRAWER = 'COLLAPSE_SETTINGS_DRAWER';
 export const OPEN_SHARE_DIALOG = 'OPEN_SHARE_DIALOG';
 export const CLOSE_SHARE_DIALOG = 'CLOSE_SHARE_DIALOG';
 export const SET_CODE = 'SET_CODE';
@@ -76,6 +78,14 @@ export function openSettingsDialog() {
 
 export function closeSettingsDialog() {
   return {type: CLOSE_SETTINGS_DIALOG};
+}
+
+export function expandSettingsDrawer() {
+  return {type: EXPAND_SETTINGS_DRAWER};
+}
+
+export function collapseSettingsDrawer() {
+  return {type: COLLAPSE_SETTINGS_DRAWER};
 }
 
 export function openShareDialog() {

--- a/website/src/store/reducers.js
+++ b/website/src/store/reducers.js
@@ -7,6 +7,7 @@ const initialState = {
 
   // UI related state
   showSettingsDialog: false,
+  showSettingsDrawer: false,
   showShareDialog: false,
   loadingSnippet: false,
   forking: false,
@@ -80,6 +81,7 @@ export function astexplorer(state=initialState, action) {
   return {
     // UI related state
     showSettingsDialog: showSettingsDialog(state.showSettingsDialog, action),
+    showSettingsDrawer: showSettingsDrawer(state.showSettingsDrawer, action),
     showShareDialog: showShareDialog(state.showShareDialog, action),
     loadingSnippet: loadSnippet(state.loadingSnippet, action),
     saving: saving(state.saving, action),
@@ -269,6 +271,17 @@ function showSettingsDialog(state=initialState.showSettingsDialog, action) {
     case actions.OPEN_SETTINGS_DIALOG:
       return true;
     case actions.CLOSE_SETTINGS_DIALOG:
+      return false;
+    default:
+      return state;
+  }
+}
+
+function showSettingsDrawer(state=initialState.showSettingsDrawer, action) {
+  switch(action.type) {
+    case actions.EXPAND_SETTINGS_DRAWER:
+      return true;
+    case actions.COLLAPSE_SETTINGS_DRAWER:
       return false;
     default:
       return state;

--- a/website/src/store/selectors.js
+++ b/website/src/store/selectors.js
@@ -24,6 +24,10 @@ export function showSettingsDialog(state) {
   return state.showSettingsDialog;
 }
 
+export function showSettingsDrawer(state) {
+  return state.showSettingsDrawer;
+}
+
 export function showShareDialog(state) {
   return state.showShareDialog;
 }


### PR DESCRIPTION
Part of https://github.com/fkling/astexplorer/issues/468
A really basic version of a settings drawer that opens and closes. Will build on this in subsequent PRs 😄 
![example-drawer](https://user-images.githubusercontent.com/9434500/75494555-70d1bb80-59b4-11ea-997a-37ce70b4233c.gif)

I've removed it from `app.js` so it doesn't actually render for users, but if you want to try it out you can undo [this commit](https://github.com/fkling/astexplorer/pull/489/commits/80c462f2ef30e24dbac8eb2a706448c151a8fd8b). Will squash when I merge, just wanted to show how it would be added to app.js in future. 