### PR TITLE
refurbish babel 7.9 support

### DIFF
--- a/website/src/parsers/js/babylon7.js
+++ b/website/src/parsers/js/babylon7.js
@@ -12,29 +12,25 @@ const availablePlugins = [
   'flowComments',
   'jsx',
   'typescript',
+  'v8intrinsic',
 
   // ECMAScript Proposals
-  'asyncGenerators',
-  'bigInt',
   'classProperties',
   'classPrivateProperties',
   'classPrivateMethods',
   'decorators',
   'doExpressions',
-  'dynamicImport',
   'exportDefaultFrom',
-  'exportNamespaceFrom',
   'functionBind',
   'functionSent',
   'importMeta',
   'logicalAssignment',
-  'nullishCoalescingOperator',
   'numericSeparator',
-  'objectRestSpread',
-  'optionalCatchBinding',
-  'optionalChaining',
+  'partialApplication',
   'pipelineOperator',
+  'recordAndTuple',
   'throwExpressions',
+  'topLevelAwait',
 ];
 
 const ID = 'babylon7';
@@ -42,32 +38,31 @@ export const defaultOptions = {
   sourceType: 'module',
   allowImportExportEverywhere: false,
   allowReturnOutsideFunction: false,
+  createParenthesizedExpressions: false,
   ranges: false,
   tokens: false,
   plugins: [
-    'asyncGenerators',
     'classProperties',
+    'classPrivateProperties',
+    'classPrivateMethods', 
     'decorators',
     'doExpressions',
-    'exportExtensions',
+    'exportDefaultFrom',
     'flow',
     'functionSent',
     'functionBind',
     'jsx',
-    'objectRestSpread',
-    'dynamicImport',
-    'nullishCoalescingOperator',
+    'logicalAssignment',
     'numericSeparator',
-    'optionalChaining',
-    'optionalCatchBinding',
   ],
 };
 
 export const parserSettingsConfiguration = {
   fields: [
-    ['sourceType', ['module', 'script']],
+    ['sourceType', ['module', 'script', 'unambiguous']],
     'allowReturnOutsideFunction',
     'allowImportExportEverywhere',
+    'createParenthesizedExpressions',
     'ranges',
     'tokens',
     {
@@ -98,14 +93,17 @@ export default {
 
   parse(babylon, code, options) {
     options = {...options};
-    // TODO: Make decoratorsBeforeExport settable through settings somhow
-    // TODO: Make pipelineOperator.proposal settable through settings somhow
+    // TODO: Make decoratorsBeforeExport settable through settings somehow
+    // TODO: Make pipelineOperator.proposal settable through settings somehow
+    // TODO: Make recordAndTuple.syntaxType settable through settings somehow
     options.plugins = options.plugins.map(plugin => {
       switch (plugin) {
         case 'decorators':
           return ['decorators', {decoratorsBeforeExport: false}];
         case 'pipelineOperator':
           return ['pipelineOperator', {proposal: 'minimal'}];
+        case 'recordAndTuple':
+          return ['recordAndTuple', { syntaxType: 'hash' }];
         default:
           return plugin;
       }


### PR DESCRIPTION
This PR refurbishes babel 7.9 support:

- Added more available proposals and language extensions
- Added more parser options
- Removed stage-4 proposals which are always enabled in `@babel/parser`
- Added stage-3 proposals to default options