### PR TITLE
Added Regexpp parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The AST explorer provides following code parsers:
 - [Pug][]
 - Regular Expressions:
   - [regexp-tree][]
+  - [regexpp][]
   - [regjsparser][]
 - Scala
   - [Scalameta][]
@@ -151,6 +152,7 @@ node.
 [redot]: https://github.com/redotjs/redot
 [remark]: https://github.com/remarkjs/remark
 [regexp-tree]: https://github.com/DmitrySoshnikov/regexp-tree
+[regexpp]: https://github.com/mysticatea/regexpp
 [regjsparser]: https://github.com/jviereck/regjsparser
 [php-parser]: https://github.com/glayzzle/php-parser
 [pug]: https://github.com/pugjs/pug
@@ -168,7 +170,7 @@ node.
 [Scalameta]: http://scalameta.org/
 [solidity-parser-antlr]: https://github.com/federicobond/solidity-parser-antlr
 [vue-template-compiler]: https://github.com/vuejs/vue/tree/dev/packages/vue-template-compiler
-[svelte]: https://github.com/sveltejs/svelte 
+[svelte]: https://github.com/sveltejs/svelte
 [hyntax]: https://github.com/nik-garmash/hyntax
 
 ### Contributions

--- a/website/package.json
+++ b/website/package.json
@@ -124,6 +124,7 @@
     "redot": "^0.6.0",
     "redux": "^4.0.5",
     "regexp-tree": "^0.1.5",
+    "regexpp": "^3.1.0",
     "regjsparser": "^0.6.0",
     "remark": "^12.0.0",
     "scalameta-parsers": "^4.2.1",

--- a/website/src/parsers/regexp/regexpp.js
+++ b/website/src/parsers/regexp/regexpp.js
@@ -35,10 +35,10 @@ export default {
 
   opensByDefault(node, key) {
     return (
-        key === 'pattern' ||
-        key === 'elements' ||
-        key === 'element' ||
-        key === 'alternatives'
+      key === 'pattern' ||
+      key === 'elements' ||
+      key === 'element' ||
+      key === 'alternatives'
     );
   },
 

--- a/website/src/parsers/regexp/regexpp.js
+++ b/website/src/parsers/regexp/regexpp.js
@@ -30,7 +30,7 @@ export default {
   },
 
   nodeToRange(node) {
-    return [node.start + 1, node.end + 1];
+    return [node.start, node.end];
   },
 
   opensByDefault(node, key) {

--- a/website/src/parsers/regexp/regexpp.js
+++ b/website/src/parsers/regexp/regexpp.js
@@ -1,0 +1,51 @@
+import defaultParserInterface from '../utils/defaultParserInterface';
+import pkg from 'regexpp/package.json';
+
+const ID = 'regexpp';
+
+/** @type {import("regexpp").RegExpParser.Options} */
+export const defaultOptions = {
+  strict: false,
+  ecmaVersion: 2020,
+};
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: ID,
+  version: pkg.version,
+  homepage: pkg.homepage,
+  locationProps: new Set(['end', 'start']),
+
+  loadParser(callback) {
+    require(['regexpp'], callback);
+  },
+
+  parse(regexpp, code, options) {
+    if (Object.keys(options).length === 0) {
+      options = this.getDefaultOptions();
+    }
+    return regexpp.parseRegExpLiteral(code, options);
+  },
+
+  nodeToRange(node) {
+    return [node.start + 1, node.end + 1];
+  },
+
+  opensByDefault(node, key) {
+    return (
+        key === 'pattern' ||
+        key === 'elements' ||
+        key === 'element' ||
+        key === 'alternatives'
+    );
+  },
+
+  getDefaultOptions() {
+    return defaultOptions;
+  },
+
+  _ignoredProperties: new Set(['parent', 'references', 'resolved']),
+
+};

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -163,6 +163,7 @@ module.exports = Object.assign({
           path.join(__dirname, 'node_modules', 'redux', 'es'),
           path.join(__dirname, 'node_modules', 'regexp-tree'),
           path.join(__dirname, 'node_modules', 'regjsparser'),
+          path.join(__dirname, 'node_modules', 'regexpp'),
           path.join(__dirname, 'node_modules', 'simple-html-tokenizer'),
           path.join(__dirname, 'node_modules', 'symbol-observable', 'es'),
           path.join(__dirname, 'node_modules', 'typescript-eslint-parser'),

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8682,6 +8682,11 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
+regexpp@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
+  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"


### PR DESCRIPTION
I added support for the [regexpp](https://github.com/mysticatea/regexpp) parser.

Or, I _think_ I did. The build (with and without my changes) fails on my system and I have no idea why.

<details>
<summary>Log</summary>

```
C:\Users\micha\Git\astexplorer\website>yarn run build
yarn run v1.22.4
$ rimraf ../out/* && cross-env NODE_ENV=production webpack --mode=production
  build [====                ] 20%[BABEL] Note: The code generator has deoptimised the styling of C:\Users\micha\Git\astexplorer\website\node_modules\prettier\standalone.js as it exceeds the max of 500KB.
  build [==============      ] 69%[BABEL] Note: The code generator has deoptimised the styling of C:\Users\micha\Git\astexplorer\website\node_modules\svelte\compiler.js as it exceeds the max of 500KB.
Build completed in 115.246s

Hash: 49b98c46074f8f4bafb8
Version: webpack 4.42.1
Time: 115251ms
Built at: 17.05.2020 23:48:07
 138 assets
Entrypoint app = runtime-e3f6ddf86dfe9a5aacab-27.js app-3759fa3ab4a75d669376-27.css app-079ae76ff4cd0a52eb74-27.js
[/mte] ./src/containers/PasteDropTargetContainer.js 777 bytes {1} [built]
[/nVi] ./css/style.css 39 bytes {1} [built]
[5Vml] ./src/containers/SettingsDialogContainer.js 1.05 KiB {1} [built]
[5obP] ./src/storage/parse.js 5.73 KiB {1} [built]
[ERIh] ./src/app.js 5.13 KiB {1} [built]
[Ehmz] ./src/containers/ErrorMessageContainer.js 802 bytes {1} [built]
[Foq9] ./src/containers/ToolbarContainer.js 2.69 KiB {1} [built]
[H9hi] ./src/store/snippetMiddleware.js 7.01 KiB {1} [built]
[IMrR] ./src/utils/debounce.js 624 bytes {1} [built]
[L4dt] ./src/store/parserMiddleware.js 2.9 KiB {1} [built]
[LTuh] ./src/containers/ASTOutputContainer.js 727 bytes {1} [built]
[RA28] ./src/storage/gist.js 6.71 KiB {1} [built]
[RCJa] ./src/containers/LoadingIndicatorContainer.js 597 bytes {1} [built]
[Sl1E] ./src/store/reducers.js 14.3 KiB {1} [built]
[Y+Aq] ./src/store/actions.js 7.03 KiB {1} [built]
    + 4621 hidden modules

WARNING in ./node_modules/traceur/bin/traceur.js (./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js) 26415:45-52
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/traceur/bin/traceur.js (./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js) 26618:45-52
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/traceur/bin/traceur.js (./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js) 26666:45-52
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/traceur/bin/traceur.js (./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js) 26690:45-52
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/traceur/bin/traceur.js (./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js) 26743:45-52
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/traceur/bin/traceur.js (./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js) 26772:45-52
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/traceur/bin/traceur.js (./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js) 26815:45-52
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/traceur/bin/traceur.js (./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js) 27063:45-52
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/traceur/bin/traceur.js (./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js) 27348:45-52
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/babel-plugin-macros/dist/index.js 112:43-50
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./src/parsers/js/transformers/babel-plugin-macros/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/source-map-support/node_modules/source-map/lib/source-map/source-map-generator.js 8:45-52
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./node_modules/source-map-support/node_modules/source-map/lib/source-map.js
 @ ./node_modules/source-map-support/source-map-support.js
 @ ./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/source-map-support/node_modules/source-map/lib/source-map/source-node.js 8:45-52
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./node_modules/source-map-support/node_modules/source-map/lib/source-map.js
 @ ./node_modules/source-map-support/source-map-support.js
 @ ./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/source-map-support/node_modules/source-map/lib/source-map/source-map-consumer.js 8:45-52
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./node_modules/source-map-support/node_modules/source-map/lib/source-map.js
 @ ./node_modules/source-map-support/source-map-support.js
 @ ./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/try-resolve/index.js 5:24-31
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./node_modules/babel5/lib/transformation/file/plugin-manager.js
 @ ./node_modules/babel5/lib/transformation/pipeline.js
 @ ./node_modules/babel5/lib/api/node.js
 @ ./node_modules/babel5/index.js
 @ ./src/parsers/js/transformers/babel/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/babel-core/lib/transformation/file/index.js 468:24-39
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/babel-core/lib/api/node.js
 @ ./node_modules/babel-core/index.js
 @ ./src/parsers/transpilers/babel.js
 @ ./src/parsers/handlebars/transformers/ember-template-recast/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/babel-core/lib/transformation/file/index.js 667:16-34
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/babel-core/lib/api/node.js
 @ ./node_modules/babel-core/index.js
 @ ./src/parsers/transpilers/babel.js
 @ ./src/parsers/handlebars/transformers/ember-template-recast/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/babel-core/lib/transformation/file/options/option-manager.js 178:19-37
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/babel-core/lib/transformation/plugin.js
 @ ./node_modules/babel-core/lib/transformation/pipeline.js
 @ ./node_modules/babel-core/lib/api/node.js
 @ ./node_modules/babel-core/index.js
 @ ./src/parsers/transpilers/babel.js
 @ ./src/parsers/handlebars/transformers/ember-template-recast/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/babel-core/lib/transformation/file/options/option-manager.js 296:16-34
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/babel-core/lib/transformation/plugin.js
 @ ./node_modules/babel-core/lib/transformation/pipeline.js
 @ ./node_modules/babel-core/lib/api/node.js
 @ ./node_modules/babel-core/index.js
 @ ./src/parsers/transpilers/babel.js
 @ ./src/parsers/handlebars/transformers/ember-template-recast/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/traceur/bin/traceur.js (./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js) 1046:38-99
Critical dependency: the request of a dependency is an expression
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/traceur/bin/traceur.js (./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js) 1046:102-123
Critical dependency: the request of a dependency is an expression
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/typescript/lib/typescript.js 5554:41-60
Critical dependency: the request of a dependency is an expression
 @ ./src/parsers/js/typescript.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/tslint/lib/ruleLoader.js 123:19-66
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/tslint/lib/index.js
 @ ./src/parsers/js/transformers/tslint/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/tslint/lib/ruleLoader.js 128:9-30
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/tslint/lib/index.js
 @ ./src/parsers/js/transformers/tslint/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/tslint/lib/formatterLoader.js 80:17-47
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/tslint/lib/index.js
 @ ./src/parsers/js/transformers/tslint/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/tslint/lib/formatterLoader.js 86:9-26
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/tslint/lib/index.js
 @ ./src/parsers/js/transformers/tslint/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/tslint/lib/formatterLoader.js 98:12-33
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/tslint/lib/index.js
 @ ./src/parsers/js/transformers/tslint/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/tslint/lib/formatterLoader.js 104:9-21
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/tslint/lib/index.js
 @ ./src/parsers/js/transformers/tslint/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/babel6/lib/transformation/file/options/option-manager.js 178:19-37
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/babel6/lib/api/node.js
 @ ./node_modules/babel6/index.js
 @ ./src/parsers/js/transformers/babel6/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/babel6/lib/transformation/file/options/option-manager.js 296:16-34
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/babel6/lib/api/node.js
 @ ./node_modules/babel6/index.js
 @ ./src/parsers/js/transformers/babel6/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/babel6/lib/transformation/file/index.js 468:24-39
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/babel6/lib/api/node.js
 @ ./node_modules/babel6/index.js
 @ ./src/parsers/js/transformers/babel6/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/babel6/lib/transformation/file/index.js 667:16-34
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/babel6/lib/api/node.js
 @ ./node_modules/babel6/index.js
 @ ./src/parsers/js/transformers/babel6/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/babel5/lib/transformation/file/index.js 537:33-45
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/babel5/lib/api/node.js
 @ ./node_modules/babel5/index.js
 @ ./src/parsers/js/transformers/babel/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/babel5/lib/transformation/file/plugin-manager.js 141:19-31
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/babel5/lib/transformation/pipeline.js
 @ ./node_modules/babel5/lib/api/node.js
 @ ./node_modules/babel5/index.js
 @ ./src/parsers/js/transformers/babel/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/import-fresh/index.js 31:31-48
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/cosmiconfig/dist/loaders.js
 @ ./node_modules/cosmiconfig/dist/index.js
 @ ./node_modules/babel-plugin-macros/dist/index.js
 @ ./src/parsers/js/transformers/babel-plugin-macros/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/tslint/lib/configuration.js 238:24-41
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/tslint/lib/index.js
 @ ./src/parsers/js/transformers/tslint/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/tslint/lib/configuration.js 272:28-53
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/tslint/lib/index.js
 @ ./src/parsers/js/transformers/tslint/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/traceur/bin/traceur.js (./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js)
Module not found: Error: Can't resolve 'vertx' in 'C:\Users\micha\Git\astexplorer\website\node_modules\traceur\bin'
 @ ./node_modules/traceur/bin/traceur.js (./node_modules/exports-loader?traceur!./node_modules/traceur/bin/traceur.js)
 @ ./src/parsers/js/traceur.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/tslint/lib/configs/recommended.d.ts 17:7
Module parse failed: Unexpected token (17:7)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|  * limitations under the License.
|  */
> export declare const rules: {
|     "adjacent-overload-signatures": boolean;
|     "array-type": {
 @ ./node_modules/tslint/lib/configs sync ^\.\/.*$ ./recommended.d.ts
 @ ./node_modules/tslint/lib/configuration.js
 @ ./node_modules/tslint/lib/index.js
 @ ./src/parsers/js/transformers/tslint/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/tslint/lib/configs/all.d.ts 17:7
Module parse failed: Unexpected token (17:7)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|  * limitations under the License.
|  */
> export declare const rules: {
|     "adjacent-overload-signatures": boolean;
|     "ban-types": {
 @ ./node_modules/tslint/lib/configs sync ^\.\/.*$ ./all.d.ts
 @ ./node_modules/tslint/lib/configuration.js
 @ ./node_modules/tslint/lib/index.js
 @ ./src/parsers/js/transformers/tslint/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

WARNING in ./node_modules/tslint/lib/configs/latest.d.ts 17:7
Module parse failed: Unexpected token (17:7)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|  * limitations under the License.
|  */
> export declare const rules: {
|     align: {
|         options: string[];
 @ ./node_modules/tslint/lib/configs sync ^\.\/.*$ ./latest.d.ts
 @ ./node_modules/tslint/lib/configuration.js
 @ ./node_modules/tslint/lib/index.js
 @ ./src/parsers/js/transformers/tslint/index.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 28:13-17
Can't import the named export 'Node' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 37:15-19
Can't import the named export 'Node' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 39:15-19
Can't import the named export 'Node' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 28:13-17
Can't import the named export 'Node' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 37:15-19
Can't import the named export 'Node' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 39:15-19
Can't import the named export 'Node' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 173:25-31
Can't import the named export 'Parser' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 173:25-31
Can't import the named export 'Parser' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 16:23-37
Can't import the named export 'SourceLocation' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 250:30-44
Can't import the named export 'SourceLocation' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 16:23-37
Can't import the named export 'SourceLocation' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 250:30-44
Can't import the named export 'SourceLocation' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 207:17-22
Can't import the named export 'Token' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 207:17-22
Can't import the named export 'Token' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1359:0-14
Can't import the named export 'defaultOptions' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1368:0-14
Can't import the named export 'defaultOptions' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 252:12-23
Can't import the named export 'getLineInfo' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 253:12-23
Can't import the named export 'getLineInfo' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 289:59-70
Can't import the named export 'getLineInfo' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 252:12-23
Can't import the named export 'getLineInfo' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 253:12-23
Can't import the named export 'getLineInfo' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 289:59-70
Can't import the named export 'getLineInfo' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 122:37-46
Can't import the named export 'isNewLine' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 178:59-68
Can't import the named export 'isNewLine' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 236:40-49
Can't import the named export 'isNewLine' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 122:37-46
Can't import the named export 'isNewLine' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 178:59-68
Can't import the named export 'isNewLine' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 236:40-49
Can't import the named export 'isNewLine' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 96:4-13
Can't import the named export 'lineBreak' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 96:4-13
Can't import the named export 'lineBreak' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 269:26-36
Can't import the named export 'lineBreakG' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 271:20-30
Can't import the named export 'lineBreakG' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 269:26-36
Can't import the named export 'lineBreakG' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 271:20-30
Can't import the named export 'lineBreakG' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 11:32-40
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 61:21-29
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 87:27-35
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 91:45-53
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 95:27-35
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 95:61-69
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 100:18-26
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 136:54-62
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 201:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 205:25-33
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 216:51-59
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 220:51-59
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 225:18-26
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 247:69-77
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 291:27-35
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 304:16-24
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 309:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 309:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 311:32-40
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 315:37-45
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 320:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 325:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 328:25-33
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 332:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 337:16-24
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 338:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 340:35-43
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 340:70-78
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 342:65-73
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 343:63-71
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 351:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 352:61-69
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 359:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 363:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 367:30-38
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 370:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 372:17-25
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 376:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 382:16-24
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 385:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 386:28-36
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 386:64-72
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 387:39-47
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 394:20-28
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 406:13-21
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 409:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 415:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 419:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 422:19-27
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 424:20-28
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 431:30-38
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 435:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 436:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 439:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 445:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 451:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 454:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 458:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 461:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 462:68-76
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 470:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 482:28-36
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 484:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 484:85-93
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 499:14-22
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 502:22-30
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 505:11-19
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 512:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 512:51-59
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 513:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 513:51-59
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 515:14-22
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 521:31-39
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 526:14-22
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 538:25-33
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 540:20-28
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 553:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 556:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 561:11-19
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 563:22-30
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 568:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 571:95-103
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 573:27-35
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 573:64-72
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 575:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 581:93-101
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 584:62-70
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 591:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 591:63-71
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 608:16-24
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 623:30-38
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 628:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 643:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 647:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 650:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 655:33-41
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 679:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 684:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 688:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 691:66-74
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 700:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 708:13-21
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 710:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 712:19-27
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 723:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 725:13-21
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 735:11-19
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 737:22-30
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 745:13-21
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 747:11-19
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 773:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 776:20-28
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 784:14-22
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 787:14-22
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 795:76-84
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 799:31-39
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 810:36-44
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 821:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 825:33-41
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 840:50-58
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 867:60-68
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 875:31-39
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 892:28-36
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 911:28-36
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 919:17-25
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 928:33-41
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 936:18-26
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 938:45-53
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 939:40-48
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 940:38-46
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 946:33-41
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 960:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 961:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 962:33-41
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 967:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 972:19-27
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 974:28-36
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 979:20-28
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 981:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 990:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 990:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 994:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 998:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 998:28-36
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 998:49-57
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1000:35-43
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1000:77-85
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1005:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1009:16-24
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1010:17-25
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1024:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1026:39-47
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1029:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1032:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1035:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1040:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1043:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1046:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1067:48-56
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1074:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1075:40-48
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1086:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1098:32-40
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1111:20-28
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1121:14-22
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1130:11-19
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1132:22-30
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1134:50-58
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1137:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1144:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1149:62-70
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1154:93-101
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1155:17-25
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1158:67-75
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1158:104-112
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1164:34-42
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1164:70-78
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1164:107-115
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1171:21-29
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1186:13-21
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1189:16-24
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1200:17-25
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1203:18-26
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1209:31-39
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1209:65-73
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1214:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1218:31-39
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1281:30-38
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1310:38-46
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1327:17-25
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/tern/node_modules/acorn-loose/dist/acorn-loose.mjs 1338:13-21
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./node_modules/tern/lib/infer.js
 @ ./src/components/JSCodeshiftEditor.js
 @ ./src/components/Transformer.js
 @ ./src/containers/TransformerContainer.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 11:32-40
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 61:21-29
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 87:27-35
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 91:45-53
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 95:27-35
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 95:61-69
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 100:18-26
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 136:54-62
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 201:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 205:25-33
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 216:51-59
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 220:51-59
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 225:18-26
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 247:69-77
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 291:27-35
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 302:16-24
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 307:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 307:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 309:32-40
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 313:37-45
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 318:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 323:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 326:25-33
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 330:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 335:16-24
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 336:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 338:35-43
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 338:70-78
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 340:65-73
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 341:63-71
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 349:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 350:61-69
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 357:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 361:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 365:30-38
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 368:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 370:17-25
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 374:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 380:16-24
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 383:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 384:28-36
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 384:64-72
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 385:39-47
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 392:20-28
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 404:13-21
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 407:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 413:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 417:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 420:19-27
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 422:20-28
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 429:30-38
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 433:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 434:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 437:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 443:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 449:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 452:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 456:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 459:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 460:68-76
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 468:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 480:28-36
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 482:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 482:85-93
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 497:14-22
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 500:22-30
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 503:11-19
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 510:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 510:51-59
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 511:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 511:51-59
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 513:14-22
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 519:31-39
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 524:14-22
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 536:25-33
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 538:20-28
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 551:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 554:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 559:11-19
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 561:22-30
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 566:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 569:95-103
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 571:27-35
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 571:64-72
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 573:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 579:93-101
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 582:62-70
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 589:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 589:63-71
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 606:16-24
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 621:30-38
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 626:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 641:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 645:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 648:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 653:33-41
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 677:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 682:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 686:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 689:66-74
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 698:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 706:13-21
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 708:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 710:19-27
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 721:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 723:13-21
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 733:11-19
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 735:22-30
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 743:13-21
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 745:11-19
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 771:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 774:20-28
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 782:14-22
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 785:14-22
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 793:76-84
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 797:31-39
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 808:36-44
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 819:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 823:33-41
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 838:50-58
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 865:60-68
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 873:31-39
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 890:28-36
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 909:28-36
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 917:17-25
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 926:33-41
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 934:18-26
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 936:45-53
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 937:40-48
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 938:38-46
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 944:33-41
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 958:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 959:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 960:33-41
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 965:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 970:19-27
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 972:28-36
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 977:20-28
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 979:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 988:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 988:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 992:26-34
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 996:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 996:28-36
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 996:49-57
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 998:35-43
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 998:77-85
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1003:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1007:16-24
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1008:17-25
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1022:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1024:39-47
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1027:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1030:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1033:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1038:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1041:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1044:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1060:7-15
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1069:35-43
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1076:48-56
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1083:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1084:40-48
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1095:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1107:32-40
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1120:20-28
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1130:14-22
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1139:11-19
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1141:22-30
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1143:50-58
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1146:15-23
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1153:29-37
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1158:62-70
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1163:93-101
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1164:17-25
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1167:67-75
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1167:104-112
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1173:34-42
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1173:70-78
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1173:107-115
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1180:21-29
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1195:13-21
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1198:16-24
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1209:17-25
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1212:18-26
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1218:31-39
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1218:65-73
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1223:24-32
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1227:31-39
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1290:30-38
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1319:38-46
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1336:17-25
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js

ERROR in ./node_modules/acorn-loose/dist/acorn-loose.mjs 1347:13-21
Can't import the named export 'tokTypes' from non EcmaScript module (only default export is available)
 @ ./src/parsers/js/acorn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^/]+\/(transformers\/([^/]+)\/)?(codeExample\.txt|[^/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/parse.js
 @ ./src/app.js
Child html-webpack-plugin for "index.html":
     1 asset
    Entrypoint undefined = index.html
    [8XHo] ./node_modules/html-webpack-plugin/lib/loader.js!./index.ejs 1.49 KiB {0} [built]
    [YuTi] (webpack)/buildin/module.js 497 bytes {0} [built]
    [yLpj] (webpack)/buildin/global.js 472 bytes {0} [built]
        + 1 hidden module
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/src/index.js!css/style.css:
    Entrypoint mini-css-extract-plugin = *
    [B5JS] ./fontcustom/fontcustom_16162f150d3b19ba44cc2e51f284fbcd.eot 80 bytes {0} [built]
    [CFTy] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/src!./css/style.css 8.84 KiB {0} [built]
    [N84m] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/src!./fontcustom/fontcustom.css 3.11 KiB {0} [built]
    [PiSq] ./fontcustom/fontcustom_16162f150d3b19ba44cc2e51f284fbcd.svg 80 bytes {0} [built]
    [VyEr] ./fontcustom/fontcustom_16162f150d3b19ba44cc2e51f284fbcd.woff 4.13 KiB {0} [built]
    [mGhM] ./fontcustom/fontcustom_16162f150d3b19ba44cc2e51f284fbcd.woff2 3.3 KiB {0} [built]
    [z1WH] ./fontcustom/fontcustom_16162f150d3b19ba44cc2e51f284fbcd.ttf 80 bytes {0} [built]
    [z9SO] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/src!./css/highlight.css 4.23 KiB {0} [built]
        + 11 hidden modules
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/src/index.js!node_modules/codemirror/addon/hint/show-hint.css:
    Entrypoint mini-css-extract-plugin = *
       2 modules
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/src/index.js!node_modules/codemirror/addon/tern/tern.css:
    Entrypoint mini-css-extract-plugin = *
       2 modules
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/src/index.js!src/components/visualization/css/tree.css:
    Entrypoint mini-css-extract-plugin = *
       2 modules
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>

Edit: Nvm. The build fails but I can still start the website. So yeah. It works.