### PR TITLE
Add Hermes parser for JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The AST explorer provides following code parsers:
   - [esformatter][]
   - [esprima][]
   - [flow-parser][]
+  - [hermes-parser][]
   - [meriyah][]
   - [recast][]
   - [seafox][]
@@ -141,6 +142,7 @@ are included so you can prototype your own plugins:
 [esprima]: https://github.com/jQuery/esprima
 [flow-parser]: https://github.com/facebook/flow/tree/master/src/parser
 [graphql]: https://facebook.github.io/graphql/
+[hermes-parser]: https://github.com/facebook/hermes/tree/master/tools/hermes-parser/js/hermes-parser
 [htmlparser2]: https://github.com/fb55/htmlparser2
 [jscodeshift]: https://github.com/facebook/jscodeshift
 [luaparse]: https://oxyc.github.io/luaparse/

--- a/website/package.json
+++ b/website/package.json
@@ -99,6 +99,7 @@
     "graphql": "^15.0.0",
     "halting-problem": "^1.0.2",
     "handlebars": "^4.7.6",
+    "hermes-parser": "^0.4.7",
     "htmlparser2": "^5.0.1",
     "hyntax": "^1.1.5",
     "intl-messageformat-parser": "^6.1.0",

--- a/website/package.json
+++ b/website/package.json
@@ -160,6 +160,7 @@
     "vue-eslint-parser": "^7.0.0",
     "vue-template-compiler": "^2.6.9",
     "webidl2": "^23.5.1",
+    "worker-loader": "^2.0.0",
     "yaml": "^1.7.2",
     "yaml-ast-parser": "^0.0.43"
   },

--- a/website/src/components/ASTOutput.js
+++ b/website/src/components/ASTOutput.js
@@ -22,7 +22,11 @@ export default function ASTOutput({parseResult={}, position=null}) {
 
   if (parseResult.error) {
     output =
-      <div style={{padding: 20}}>
+      <div style={{
+        padding: 20,
+        whiteSpace: 'pre-wrap',
+        fontFamily: 'monospace',
+      }}>
         {parseResult.error.message}
       </div>;
   } else if (ast) {
@@ -98,4 +102,3 @@ class ErrorBoundary extends React.Component {
 ErrorBoundary.propTypes = {
   children: PropTypes.node,
 };
-

--- a/website/src/parsers/js/hermes.js
+++ b/website/src/parsers/js/hermes.js
@@ -1,0 +1,50 @@
+import defaultParserInterface from './utils/defaultESTreeParserInterface';
+// NOTE: We load the hermes-parser package in a worker and not directly, because
+// it violates the typical limit on the size of a WebAssembly module that can be
+// compiled synchronously on the main thread.
+import HermesWorkerClient from './hermes/HermesWorkerClient';
+import pkg from 'hermes-parser/package.json';
+
+export const defaultOptions = {
+  sourceType: 'unambiguous',
+  flow: 'detect',
+  allowReturnOutsideFunction: false,
+  babel: false,
+  tokens: false,
+};
+
+export const parserSettingsConfiguration = {
+  fields: [
+    ['sourceType', ['unambiguous', 'module', 'script']],
+    ['flow', ['detect', 'all']],
+    'allowReturnOutsideFunction',
+    'babel',
+    'tokens',
+  ],
+};
+
+export default {
+  ...defaultParserInterface,
+
+  id: 'hermes',
+  displayName: pkg.name,
+  version: pkg.version,
+  homepage: pkg.homepage || 'https://hermesengine.dev/',
+  locationProps: new Set(['range', 'loc']),
+
+  loadParser(callback) {
+    callback(new HermesWorkerClient());
+  },
+
+  async parse(hermes, code, options) {
+    return await hermes.parse(code, options);
+  },
+
+  getDefaultOptions() {
+    return defaultOptions;
+  },
+
+  _getSettingsConfiguration() {
+    return parserSettingsConfiguration;
+  },
+};

--- a/website/src/parsers/js/hermes/HermesWorkerClient.js
+++ b/website/src/parsers/js/hermes/HermesWorkerClient.js
@@ -1,0 +1,46 @@
+// Some ESLint rules don't understand the Webpack loader syntax.
+// eslint-disable-next-line require-in-package/require-in-package, import/default
+import HermesWorker from 'worker-loader!./hermes-worker.js';
+
+// A Promise-based client for making requests to hermes-worker.js.
+export default class HermesWorkerClient {
+  constructor() {
+    this._nextRequestId = 0;
+    this._requests = new Map();
+    this._worker = new HermesWorker();
+    this._worker.onmessage = this._handleMessage.bind(this);
+  }
+
+  _handleMessage(e) {
+    const {type, action, value, requestId} = e.data;
+    const request = this._requests.get(requestId);
+    if (!request) {
+      throw new Error(
+        `Received a response for a nonexistent '${type}' request ID: ${requestId}`,
+      );
+    }
+    this._requests.delete(requestId);
+    switch (action) {
+      case 'resolve':
+        request.resolve(value);
+        break;
+      case 'reject':
+        // The worker sends errors as plain objects to work around the
+        // limitations of the structured clone algorithm.
+        request.reject(Object.assign(new Error(), value));
+        break;
+    }
+  }
+
+  _request(type, args) {
+    return new Promise((resolve, reject) => {
+      const requestId = this._nextRequestId++;
+      this._requests.set(requestId, {resolve, reject});
+      this._worker.postMessage({type, args, requestId});
+    });
+  }
+
+  parse(...args) {
+    return this._request('parse', args);
+  }
+}

--- a/website/src/parsers/js/hermes/hermes-worker.js
+++ b/website/src/parsers/js/hermes/hermes-worker.js
@@ -1,0 +1,38 @@
+/* eslint-env worker */
+
+// A Web Worker that wraps methods from the hermes-parser package behind a
+// minimal request/response protocol.
+
+import hermesParser from 'hermes-parser';
+
+const handlers = {
+  parse(code, options) {
+    return hermesParser.parse(code, options);
+  },
+};
+
+onmessage = async function(e) {
+  const {type, requestId, args = []} = e.data;
+  let handler = () => {
+    throw new Error('No handler in Hermes worker for message type: ' + type);
+  };
+  if (Object.hasOwnProperty.call(handlers, type)) {
+    handler = handlers[type];
+  }
+  let value;
+  try {
+    value = handler(...args);
+  } catch (e) {
+    postMessage({
+      type,
+      requestId,
+      action: 'reject',
+      // Errors don't survive the structured clone algorithm very well across
+      // browsers - they're either not allowed or lose some of their properties.
+      // Send a plain-object copy to be reconstituted by the client.
+      value: {name: e.name, stack: e.stack, message: e.message, ...e},
+    });
+    return;
+  }
+  postMessage({type, requestId, action: 'resolve', value});
+};

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -57,6 +57,7 @@
     source-map "^0.5.0"
 
 "@babel/core@^7.1.6", "babel7@npm:@babel/core@^7":
+  name babel7
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.0.tgz#47299ff3ec8d111b493f1a9d04bf88c04e728d88"
   integrity sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==
@@ -7110,7 +7111,7 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.0.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -9832,6 +9833,14 @@ scheduler@^0.19.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+schema-utils@^0.4.0:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
+  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
@@ -11517,6 +11526,14 @@ worker-farm@^1.7.0:
   integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
   dependencies:
     errno "~0.1.7"
+
+worker-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
+  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
+  dependencies:
+    loader-utils "^1.0.0"
+    schema-utils "^0.4.0"
 
 workerpool@^6.0.3:
   version "6.0.3"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6102,6 +6102,11 @@ he@1.2.x, he@^1.1.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+hermes-parser@^0.4.7:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.4.7.tgz#410f5129d57183784d205a0538e6fbdcf614c9ea"
+  integrity sha512-jc+zCtXbtwTiXoMAoXOHepxAaGVFIp89wwE9qcdwnMd/uGVEtPoY8FaFSsx0ThPvyKirdR2EsIIDVrpbSXz1Ag==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
(EDIT: Updated June 2021.)

Adds the [Hermes engine](https://github.com/facebook/hermes)'s parser into AST Explorer. Try it at [astexplorer-hermes.now.sh](https://astexplorer-hermes.now.sh).

![screenshot of AST Explorer with the Hermes parser](https://user-images.githubusercontent.com/2246565/120918090-826f3c00-c6aa-11eb-9c4f-a05a5d2a0f08.png)

Implementation notes:
1. This uses the official [hermes-parser](https://www.npmjs.com/package/hermes-parser) npm package and supports all of its options (except `sourceFilename`).
2. We wrap the parser in a Web Worker, because some browsers will refuse to synchronously load a WebAssembly module on the main thread when it's as big as the one `hermes-parser` uses. As a side benefit, this is also nice for UI perf.
3. There is some subtlety to how errors are reported because of the worker architecture - sending `Error` instances over `postMessage` behaves differently across browsers so I've ditched that. The current solution is portable (tested in Chrome, Firefox and Safari) and preserves the error location data for use in the editor.
4. I've snuck in a tiny CSS change so that errors are displayed in a monospace font with whitespace preserved. This improves error output for parsers (like `hermes-parser`) that include code frames in their error messages.
5. Hermes and `hermes-parser` are versioned independently, so to prevent confusion I used `hermes-parser` as the display name even though the word "parser" is redundant in context.