### PR TITLE
JavaScript, Babylon7, support selecting pipeline proposal

### DIFF
--- a/website/src/parsers/js/babylon7.js
+++ b/website/src/parsers/js/babylon7.js
@@ -44,7 +44,7 @@ export const defaultOptions = {
   plugins: [
     'classProperties',
     'classPrivateProperties',
-    'classPrivateMethods', 
+    'classPrivateMethods',
     'decorators',
     'doExpressions',
     'exportDefaultFrom',
@@ -75,6 +75,7 @@ export const parserSettingsConfiguration = {
         {},
       ),
     },
+    ['pipelineProposal', ['minimal', 'smart', 'fsharp']],
   ],
 };
 
@@ -101,7 +102,7 @@ export default {
         case 'decorators':
           return ['decorators', {decoratorsBeforeExport: false}];
         case 'pipelineOperator':
-          return ['pipelineOperator', {proposal: 'minimal'}];
+          return ['pipelineOperator', {proposal: options.pipelineProposal}];
         case 'recordAndTuple':
           return ['recordAndTuple', { syntaxType: 'hash' }];
         default:


### PR DESCRIPTION
Supports selecting whichever pipeline proposal.

I'm gonna add "hack" (hopefully after adding it to Babel) later.

Before this commit:
<img width="1680" alt="Screen Shot 2020-05-22 at 16 32 43" src="https://user-images.githubusercontent.com/1473433/82715886-e662c600-9c49-11ea-8499-d7c5ca58d6d0.png">

After this commit:
<img width="1638" alt="Screen Shot 2020-05-22 at 16 32 30" src="https://user-images.githubusercontent.com/1473433/82715891-ea8ee380-9c49-11ea-8120-a70f5b85d8de.png">
