### PR TITLE
chore: disable package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /out
 node_modules
 .idea
+package-lock.json

--- a/website/.npmrc
+++ b/website/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
I assumed `package-lock.json` wasn't meant to be checked in, seeing as it wasn't already in the repo.

Disabling it at a repo level so it doesn't get generated in the first place.