### PR TITLE
Add a category and the corresponding template parser for San

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -133,6 +133,7 @@
     "regexpp": "^3.1.0",
     "regjsparser": "^0.6.0",
     "remark": "^12.0.0",
+    "san": "^3.9.4",
     "scalameta-parsers": "^4.2.1",
     "seafox": "^1.6.9",
     "shift-parser": "^7.0.0",

--- a/website/src/parsers/san/codeExample.txt
+++ b/website/src/parsers/san/codeExample.txt
@@ -1,0 +1,7 @@
+<div>
+  <h2 s-if="title">{{title}}</h2>
+  <form>
+    <input type="text" name="foo">
+    <button on-click="onBtnClick">submit</button>
+  </form>
+</div>

--- a/website/src/parsers/san/index.js
+++ b/website/src/parsers/san/index.js
@@ -1,0 +1,7 @@
+import 'codemirror/mode/htmlmixed/htmlmixed';
+
+export const id = 'san';
+export const displayName = 'San';
+export const mimeTypes = ['text/html'];
+export const fileExtension = 'san.html';
+export const editorMode = 'htmlmixed';

--- a/website/src/parsers/san/san-template-parser.js
+++ b/website/src/parsers/san/san-template-parser.js
@@ -1,0 +1,36 @@
+import defaultParserInterface from '../utils/defaultParserInterface';
+import pkg from 'san/package.json';
+
+const ID = 'san';
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: ID,
+  version: pkg.version,
+  homepage: pkg.homepage,
+  locationProps: new Set([]),
+  typeProps: new Set(['tag']),
+
+  loadParser(callback) {
+    require(['san'], callback);
+  },
+
+  parse(parser, code, options) {
+    return parser.parseTemplate(code, options).children[0];
+  },
+
+  opensByDefault(node, key) {
+    return key === 'children';
+  },
+
+  getNodeName(node) {
+    return node.tagName;
+  },
+
+  getDefaultOptions() {
+    return {};
+  },
+  _ignoredProperties: new Set([]),
+};

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -9255,6 +9255,11 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+san@^3.9.4:
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/san/-/san-3.9.4.tgz#95120241bd019cf0358135ac6fd3c44af475d789"
+  integrity sha512-E9q/HOv5XWUz6TmoGZthbhbkXyHlzCBrUZFKMO42+JVRJsai0ie8n3jntgYUFRI5LdNHnlZWSg+XJfyJxpjIZg==
+
 scalameta-parsers@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/scalameta-parsers/-/scalameta-parsers-4.2.1.tgz#639810efdcf925e9b78f3f47022afaf64d09f125"


### PR DESCRIPTION
I'm working on san related projects and find it extreme useful to have a AST viewer for it. And then  I find astexplorer as a start point. After using my local astexplorer for a while and made [some changes on san](https://github.com/baidu/san/pull/527/files) to work well with astexplorer, I find it's potentially also useful for many people working on or using san.

San is an MVVM component-based framework, basically similiar to Vue but, fosusing on compatibility and performance. Here's a template parser using its own `parseTemplate()`. See this page for more about San: https://baidu.github.io/san/en/index.html

The AST tree viewer for San template is useful for both development for [san][san], [san-ssr][san-ssr] and build tools like [san-anode-utils][san-anode-utils] and [san-cli][san-cli].

[san]: https://github.com/baidu/san
[san-ssr]: https://github.com/baidu/san-ssr
[san-anode-utils]: https://github.com/ecomfe/san-anode-utils
[san-cli]: https://github.com/ecomfe/san-cli