### PR TITLE
Fix avoid hiding empty array elements

### DIFF
--- a/website/src/core/TreeAdapter.js
+++ b/website/src/core/TreeAdapter.js
@@ -200,9 +200,7 @@ export function functionFilter() {
   return {
     key: 'hideFunctions',
     label: 'Hide methods',
-    test(value) {
-      return typeof value === 'function';
-    },
+    test(value) { return typeof value === 'function'; },
   };
 }
 
@@ -210,9 +208,7 @@ export function emptyKeysFilter() {
   return {
     key: 'hideEmptyKeys',
     label: 'Hide empty keys',
-    test(value, key, fromArray) {
-      return value == null && !fromArray;
-    },
+    test(value, key, fromArray) { return value == null && !fromArray; },
   };
 }
 

--- a/website/src/core/TreeAdapter.js
+++ b/website/src/core/TreeAdapter.js
@@ -108,7 +108,7 @@ class TreeAdapter {
             if (filter.key && !this._filterValues[filter.key]) {
               return false;
             }
-            return filter.test(result.value, result.key);
+            return filter.test(result.value, result.key, Array.isArray(node));
           })
         ) {
           continue;
@@ -200,7 +200,9 @@ export function functionFilter() {
   return {
     key: 'hideFunctions',
     label: 'Hide methods',
-    test(value) { return typeof value === 'function'; },
+    test(value) {
+      return typeof value === 'function';
+    },
   };
 }
 
@@ -208,7 +210,9 @@ export function emptyKeysFilter() {
   return {
     key: 'hideEmptyKeys',
     label: 'Hide empty keys',
-    test(value) { return value == null; },
+    test(value, key, fromArray) {
+      return value == null && !fromArray;
+    },
   };
 }
 


### PR DESCRIPTION
This allows holes to be visible in code like:

```mjs
let foo = [1,,3];
let [a,,c] = foo;
```

This also means humans reading arrays can see the correct index while viewing.