### PR TITLE
Update Rust parser to syn 1.0

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -59,7 +59,7 @@
     "acorn-to-esprima": "^2.0.8",
     "astexplorer-go": "^1.0.0",
     "astexplorer-refmt": "^1.0.1",
-    "astexplorer-syn": "^0.15.30",
+    "astexplorer-syn": "^1.0.48",
     "babel-core": "^6.24.0",
     "babel-eslint": "^7.2.3",
     "babel-eslint8": "npm:babel-eslint@^8",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2061,10 +2061,10 @@ astexplorer-refmt@^1.0.1:
   resolved "https://registry.yarnpkg.com/astexplorer-refmt/-/astexplorer-refmt-1.0.1.tgz#490875d350a1cf0136404d8d71f940012aa9dc78"
   integrity sha512-sFMDDWb7/rBuR1qCGuAXw1FdP1ArIjgVPDGtb3DuziXfM2qzLwLM+RUnSM6m9n8RYyzCUgPdvTkTesECZ4e2mQ==
 
-astexplorer-syn@^0.15.30:
-  version "0.15.30"
-  resolved "https://registry.yarnpkg.com/astexplorer-syn/-/astexplorer-syn-0.15.30.tgz#692370cf6991b2f56c09946042676082dd1b47cd"
-  integrity sha512-9HOKSIUPJlfwX8Kj7SQApbbl02IDqe+guNw+eGAZJnFadYopaGLavlcnAdPODsExjlnUmGL1rV1iJvAGDXnTPg==
+astexplorer-syn@^1.0.48:
+  version "1.0.48"
+  resolved "https://registry.yarnpkg.com/astexplorer-syn/-/astexplorer-syn-1.0.48.tgz#1eb4af025ed3c30b765ef899f4e565bbaa4de3d1"
+  integrity sha512-KnZVFhSZ1O0Xrg5lWjtxRkbYpGgPKYdTGwVXFl3sXT9L54YmjRB6Gyq9ar1bG13JRmNR8aTPZXqW5aQDW4HC3A==
 
 astral-regex@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR pulls in the newest version of the Rust parser:

- A few syntax tree changes in the underlying Rust library between 0.15 and 1.0: https://github.com/dtolnay/syn/releases/tag/1.0.0#user-content-breaking-changes

- The corresponding PR to the npm package: https://github.com/RReverser/astexplorer-syn/pull/1

---

![Screenshot](https://user-images.githubusercontent.com/1940490/97093973-48fb2c00-1605-11eb-8ca1-6d9eb4f6a82e.png)