### PR TITLE
[WIP] Add swc JavaScript parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The AST explorer provides following code parsers:
   - [recast][]
   - [seafox][]
   - [shift][]
+  - [swc][]
   - [traceur][]
   - [typescript][]
   - [typescript-eslint-parser][]
@@ -97,6 +98,7 @@ are included so you can prototype your own plugins:
   - [babel][] (v5, v6)
   - [ESLint][] (v1, v2, v3)
   - [jscodeshift][]
+  - [swc][]
   - [tslint][]
 - HTML
   - [posthtml][]
@@ -152,6 +154,7 @@ are included so you can prototype your own plugins:
 [seafox]: https://github.com/KFlash/seafox
 [rework]: https://github.com/reworkcss/rework
 [shift]: https://github.com/shapesecurity/shift-parser-js
+[swc]: https://github.com/swc-project/swc
 [traceur]: https://github.com/google/traceur-compiler
 [typescript]: https://github.com/Microsoft/TypeScript/
 [typescript-eslint-parser]: https://github.com/eslint/typescript-eslint-parser/

--- a/website/package.json
+++ b/website/package.json
@@ -50,6 +50,7 @@
     "@glimmer/syntax": "^0.50.3",
     "@humanwhocodes/momoa": "^1.0.0",
     "@mdx-js/mdx": "^1.5.8",
+    "@swc/wasm-web": "^1.2.43",
     "@typescript-eslint/parser": "^4.1.0",
     "@vue/compiler-dom": "^3.0.0-rc.10",
     "@webassemblyjs/wast-parser": "^1.9.0",

--- a/website/src/parsers/js/swc.js
+++ b/website/src/parsers/js/swc.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import defaultParserInterface from './utils/defaultESTreeParserInterface';
+import pkg from '@swc/wasm-web/package.json';
+
+const ID = 'swc';
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: ID,
+  version: `${pkg.version}`,
+  homepage: 'https://swc.rs/',
+  locationProps: new Set(['span']),
+
+  loadParser(callback) {
+    require(['@swc/wasm-web/wasm.js'], callback);
+  },
+
+  parse(parser, code, options={}) {
+    try {
+      return parser.parseSync(code, options);
+    } catch (message) {
+      // AST Explorer expects the thrown error to be an object, not a string.
+      throw new SyntaxError(message);
+    }
+  },
+
+  nodeToRange(node) {
+    if (node && node.span && typeof node.span.start === 'number') {
+      return [node.span.start, node.span.end];
+    }
+  },
+
+  getDefaultOptions() {
+    return {
+      syntax: 'ecmascript',
+    };
+  },
+
+  _getSettingsConfiguration() {
+    return {
+      fields: [
+        ['syntax', ['ecmascript', 'typescript']],
+      ],
+    };
+  },
+
+};

--- a/website/src/parsers/js/transformers/swc/codeExample.txt
+++ b/website/src/parsers/js/transformers/swc/codeExample.txt
@@ -1,0 +1,25 @@
+{
+    "jsc": {
+        "target": "es3",
+        "parser": {
+            "syntax": "ecmascript"
+        },
+        "transform": {
+            "optimizer": {
+                "globals": {
+                    "vars": {
+                        "__DEBUG__": "true"
+                    }
+                }
+            }
+        }
+    },
+    "minify": false,
+    "module": {
+        "type": "commonjs",
+        "strict": false,
+        "strictMode": true,
+        "lazy": false,
+        "noInterop": false
+    }
+}

--- a/website/src/parsers/js/transformers/swc/index.js
+++ b/website/src/parsers/js/transformers/swc/index.js
@@ -1,0 +1,24 @@
+import pkg from '@swc/wasm-web/package.json';
+
+const ID = 'swc';
+
+export default {
+    id: ID,
+    displayName: ID,
+    version: `${pkg.version}`,
+    homepage: 'https://swc.rs/',
+
+    defaultParserID: ID,
+
+    loadTransformer(callback) {
+        require(['@swc/wasm-web/wasm'], callback);
+    },
+
+    transform(swc, options, code) {
+        try {
+            return swc.transformSync(code, JSON.parse(options));
+        } catch (e) {
+            throw new SyntaxError(e);
+        }
+    },
+};

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -175,6 +175,7 @@ module.exports = Object.assign({
           path.join(__dirname, 'node_modules', 'regexpp'),
           path.join(__dirname, 'node_modules', 'simple-html-tokenizer'),
           path.join(__dirname, 'node_modules', 'symbol-observable', 'es'),
+          path.join(__dirname, 'node_modules', 'swc', '@wasm-web'),
           path.join(__dirname, 'node_modules', 'typescript-eslint-parser'),
           path.join(__dirname, 'node_modules', 'webidl2'),
           path.join(__dirname, 'node_modules', 'tslint'),

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1610,6 +1610,11 @@
   resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
   integrity sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==
 
+"@swc/wasm-web@^1.2.43":
+  version "1.2.43"
+  resolved "https://registry.yarnpkg.com/@swc/wasm-web/-/wasm-web-1.2.43.tgz#9b52f6a5e58b36e639ab344b94cf659d55c61d39"
+  integrity sha512-uSn/XvwT3gIaSFQUZH32fYiBvxo3GZropKFK7A/8DexO29zU7Yn4K0UxP6QRivyiYeHAq9hwrVayHcr77gsZDA==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"


### PR DESCRIPTION
> swc is a super-fast compiler written in rust; producing widely-supported javascript from modern standards and typescript.

Expose the swc parser in AST Explorer. This parser is built using Rust, and the client side version relies on WebAssembly.

Known bug: any action (editing the code or changing a setting) breaks the Autofocus feature, and requires a page reload.

Closes #555.