### PR TITLE
Adds "tsx" as a parser within the recast parser

### DIFF
--- a/website/src/parsers/js/recast.js
+++ b/website/src/parsers/js/recast.js
@@ -19,8 +19,8 @@ export default {
 
   loadParser(callback) {
     require(
-      ['recast', 'babel5', 'babylon6', 'babylon7', 'flow-parser', 'recast/parsers/typescript'],
-      (recast, babelCore, babylon6, babylon7, flow, typescript) => {
+      ['recast', 'babel5', 'babylon6', 'babylon7', 'flow-parser', 'recast/parsers/typescript', './utils/recast-tsx-parser'],
+      (recast, babelCore, babylon6, babylon7, flow, typescript, tsx) => {
         callback({
           recast,
           parsers: {
@@ -29,6 +29,7 @@ export default {
             babylon7,
             flow,
             typescript,
+            tsx,
           },
         });
       },
@@ -72,6 +73,9 @@ export default {
       case 'typescript':
         options.parser = parsers.typescript;
         break
+      case 'tsx':
+          options.parser = parsers.tsx;
+          break
       default:
         delete options.parser; // default parser
         break;
@@ -119,7 +123,7 @@ export default {
   _getSettingsConfiguration(defaultOptions) {
     return {
       fields: [
-        ['parser', ['esprima', 'babel5', 'babylon6', 'babylon7', 'flow', 'typescript']],
+        ['parser', ['esprima', 'babel5', 'babylon6', 'babylon7', 'flow', 'typescript', 'tsx']],
         'range',
         'tolerant',
         {

--- a/website/src/parsers/js/utils/recast-tsx-parser.js
+++ b/website/src/parsers/js/utils/recast-tsx-parser.js
@@ -1,0 +1,11 @@
+import babel_options from 'recast/parsers/_babel_options';
+import { parser } from 'recast/parsers/babel';
+
+// modified version of recast/parsers/typescript.js that also
+// adds the jsx plugin
+export function parse(source, options) {
+  var babelOptions = babel_options(options);
+  babelOptions.plugins.push('typescript');
+  babelOptions.plugins.push('jsx');
+  return parser.parse(source, babelOptions);
+}


### PR DESCRIPTION
Adds a new option inside the Recast parser settings for a "tsx" parser.

![Screen Shot 2021-02-02 at 8 18 36 AM](https://user-images.githubusercontent.com/303023/106620978-55a9ed00-652f-11eb-9b84-efca1846743b.png)
