### PR TITLE
provide location information for shift-parser

### DIFF
--- a/website/src/parsers/utils/defaultParserInterface.js
+++ b/website/src/parsers/utils/defaultParserInterface.js
@@ -84,7 +84,7 @@ export default {
   /**
    * A generator to iterate over each "property" of the node. Overwriting this
    * function allows a parser to expose information from a node if the node
-   * is not implemnted as plain JavaScript object.
+   * is not implemented as plain JavaScript object.
    */
   *forEachProperty(node) {
     if (node && typeof node === 'object') {


### PR DESCRIPTION
I don't love the global state approach to storing side tables, but it seems to be the preferred approach (I copied it from the [typescript parser](https://github.com/fkling/astexplorer/blob/a565b32ecce73118ad82bbf5997367b19bd02f94/website/src/parsers/js/typescript.js#L66)).