### PR TITLE
feat: [transformers] add example formatting + compatible parsers

### DIFF
--- a/website/src/parsers/js/transformers/jscodeshift/codeExample.txt
+++ b/website/src/parsers/js/transformers/jscodeshift/codeExample.txt
@@ -1,3 +1,7 @@
+// jscodeshift can take a parser, like "babel", "babylon", "flow", "ts", or "tsx"
+// Read more: https://github.com/facebook/jscodeshift#parser
+export const parser = '{{parser}}'
+
 // Press ctrl+space for code completion
 export default function transformer(file, api) {
   const j = api.jscodeshift;

--- a/website/src/parsers/js/transformers/jscodeshift/index.js
+++ b/website/src/parsers/js/transformers/jscodeshift/index.js
@@ -5,6 +5,20 @@ const ID = 'jscodeshift';
 
 const sessionMethods = new Set();
 
+// https://github.com/facebook/jscodeshift#parser
+const getJscodeshiftParser = (parser, parserSettings) => {
+  if (parser === 'typescript') {
+    if (parserSettings.typescript && parserSettings.typescript.jsx === false) {
+      return 'ts'
+    }
+    return 'tsx'
+  }
+  if (parser === 'flow') {
+    return 'flow'
+  }
+  return 'babel'
+}
+
 export default {
   id: ID,
   displayName: ID,
@@ -12,6 +26,14 @@ export default {
   homepage: pkg.homepage || 'https://github.com/facebook/jscodeshift',
 
   defaultParserID: 'recast',
+  compatibleParserIDs: new Set([
+    'typescript',
+    'flow',
+  ]),
+
+  formatCodeExample(codeExample, { parser, parserSettings }) {
+    return codeExample.replace('{{parser}}', `${getJscodeshiftParser(parser, parserSettings)}`)
+  },
 
   loadTransformer(callback) {
     require(['../../../transpilers/babel', 'jscodeshift'], (transpile, jscodeshift) => {


### PR DESCRIPTION
Looking for a little discussion on approach! I use AST explorer only every so often and most recently I found myself stumbling a bit again when I tried to write a jscodeshift transform, and was only met with the error below:

![image](https://user-images.githubusercontent.com/3484848/120607173-c80adb00-c404-11eb-88e2-5e4c2a2ca3e2.png)

Here's an attempt to demystify some of this by adding the `module.exports.parser` directly to the code example (with a cute little formatter to automatically inject the "tsx" transformer)

Here's a gif of the flow:

https://user-images.githubusercontent.com/3484848/120608590-34d2a500-c406-11eb-86da-6c49c89bc298.mp4

----

This adds two new configuration options for transformers:
- compatibleParserIDs
- formatCodeExample

compatibleParserIDs is used in SELECT_TRANSFORMER as an alternative to
always resetting the parser when changing the transformer or turning it
on. If we are already on a compatible parser, we won't change.

formatCodeExample supports custom formatting/templating for code
examples - in the case of jscodeshift, this is used to set the
module.exports.parser based on current parser.

In combination, this supports a workflows like:
- Copy in a typescript file contents
- Change the parser to typescript
- Turn on the transform for jscodeshift

