### PR TITLE
Fix node range handling in Hermes parser adapter

### DIFF
--- a/website/src/parsers/js/hermes.js
+++ b/website/src/parsers/js/hermes.js
@@ -30,7 +30,7 @@ export default {
   displayName: pkg.name,
   version: pkg.version,
   homepage: pkg.homepage || 'https://hermesengine.dev/',
-  locationProps: new Set(['range', 'loc']),
+  locationProps: new Set(['range', 'loc', 'start', 'end']),
 
   loadParser(callback) {
     callback(new HermesWorkerClient());
@@ -39,6 +39,15 @@ export default {
   async parse(hermes, code, options) {
     return await hermes.parse(code, options);
   },
+
+  nodeToRange(node) {
+    // For `babel: true` mode
+    if (typeof node.start !== 'undefined') {
+      return [node.start, node.end];
+    }
+    // For `babel: false` mode
+    return node.range;
+  },  
 
   getDefaultOptions() {
     return defaultOptions;


### PR DESCRIPTION
Quick follow up from #504 fixing location handling with the Hermes parser. Adds a `nodeToRange` method supporting the two different AST formats generated by `hermes-parser`, as well as matching `locationProps`.

Test plan:

1. Ensure that "Hide location data" works for both `babel: false` and `babel: true`.
2. Ensure that hovering a node highlights the corresponding code for both `babel: false` and `babel: true`.