### PR TITLE
fix: site stuck in infinite loop

### DIFF
--- a/website/src/parsers/html/angular.js
+++ b/website/src/parsers/html/angular.js
@@ -83,6 +83,7 @@ function getNodeCtor(node) {
  *                  ^^^^^^^^^^ sub AST { start: 13, end: 23 }
  */
 function fixSpan(ast, code) {
+  const fixed = new Set();
   const KEEP_VISIT = 1;
   function visitTarget(value, isTarget, fn, parent) {
     if (value !== null && typeof value === 'object') {
@@ -106,9 +107,21 @@ function fixSpan(ast, code) {
     switch (nodeName) {
       case 'BoundAttribute':
       case 'BoundEvent': {
-        let offset = parent.sourceSpan.start.offset;
-        while (code[offset++] !== '=');
+        let {offset} = parent.sourceSpan.start;
+        const isStructuralBinding = !/[\[(]/.test(code[offset]);
+        if (isStructuralBinding) {
+          return offset;
+        }
+
+        const assignment = /[=:]/;
+        while (code[offset] && !assignment.test(code[offset++]));
+
+        if (!code[offset]) {
+          console.warn('Unable to fix span values', parent);
+        }
+
         if (code[offset] === "'" || code[offset] === '"') offset++;
+
         return offset;
       }
       case 'BoundText':
@@ -127,8 +140,12 @@ function fixSpan(ast, code) {
         node,
         value => value.span,
         node => {
-          node.span.start += baseStart;
-          node.span.end += baseStart;
+          if (!fixed.has(node)) {
+            node.span.start += baseStart;
+            node.span.end += baseStart;
+            fixed.add(node);
+          }
+
           return KEEP_VISIT;
         },
       );


### PR DESCRIPTION
This PR fixes the following issues:

1. When using the Angular HTML parser, the site crashes (stuck in an infinite loop) with the following template:

```html
<div *ngFor="let hero of heroes; let i=index; let odd=odd; trackBy: trackById">
  ({{i}}) {{hero.name}}
</div>
```

This is caused by the `fixSpan` method, which isn't handling bound attributes from structural directives and has a `while` loop with a stop condition that doesn't meet in this case.

2. The attribute span indexes are incorrect since it returns the first `=` index after the attribute, for example:

```html
<div *ngFor="let hero of heroes; let i=index; let odd=odd; trackBy: trackById" [class.odd]="odd">
  ({{i}}) {{hero.name}}
</div>
```
* The `ngForOf` bound attribute should have the following span: `{start: 22, end: 28}` but it actually resolves to 
`{start: 39, end: 45}` which is the `=` char index of the template variable `i`.
* The `ngForTrackBy` bound attribute should have the following span: `{start: 59, end: 68}` but it actually resolves to `{start: 92, end: 102}` which is the `=` char of the `class.odd` bound attribute.

3. The input span indexes are wrong for inputs with structural directives (`[class.odd]="odd"`)

The span for this attribute should be `{start: 92, end: 95}` but it's actually `{start: 184, end: 187}` this is because this attribute is referenced both as an input to the `Template` node and as an input to the `Element` node (the `div`)