### PR TITLE
Upgrade svelte transformer to version 3.44.3

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -149,7 +149,7 @@
     "solidity-parser-diligence": "^0.4.18",
     "source-map": "^0.6.1",
     "sqlite-parser": "^1.0.0-rc3",
-    "svelte": "^3.4.1",
+    "svelte": "^3.44.3",
     "tenko": "^1.0.6",
     "tern": "^0.24.3",
     "traceur": "0.0.111",

--- a/website/package.json
+++ b/website/package.json
@@ -149,7 +149,7 @@
     "solidity-parser-diligence": "^0.4.18",
     "source-map": "^0.6.1",
     "sqlite-parser": "^1.0.0-rc3",
-    "svelte": "^3.44.3",
+    "svelte": "^3.46.2",
     "tenko": "^1.0.6",
     "tern": "^0.24.3",
     "traceur": "0.0.111",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -10322,10 +10322,10 @@ supports-color@^8.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-svelte@^3.4.1:
-  version "3.20.1"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.20.1.tgz#8417fcd883a2f534b642a0737368272e651cf3ac"
-  integrity sha512-m/dw52BZf+p6KYnyKLErIcGalu4pwJrQbUM7VZriRw6ZlJj1qMAZsLcIWzEB3I0hhdJwkKb7LrrvUIeqmbO92Q==
+svelte@^3.44.3:
+  version "3.44.3"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.44.3.tgz#795b1ced6ed3da44969099e5061b850c93c95e9a"
+  integrity sha512-aGgrNCip5PQFNfq9e9tmm7EYxWLVHoFsEsmKrtOeRD8dmoGDdyTQ+21xd7qgFd8MNdKGSYvg7F9dr+Tc0yDymg==
 
 symbol-observable@^1.2.0:
   version "1.2.0"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -10322,10 +10322,10 @@ supports-color@^8.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-svelte@^3.44.3:
-  version "3.44.3"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.44.3.tgz#795b1ced6ed3da44969099e5061b850c93c95e9a"
-  integrity sha512-aGgrNCip5PQFNfq9e9tmm7EYxWLVHoFsEsmKrtOeRD8dmoGDdyTQ+21xd7qgFd8MNdKGSYvg7F9dr+Tc0yDymg==
+svelte@^3.46.2:
+  version "3.46.2"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.46.2.tgz#f0ffbffaea3a9a760edcbefc0902b41998a686ad"
+  integrity sha512-RXSAtYNefe01Sb1lXtZ2I+gzn3t/h/59hoaRNeRrm8IkMIu6BSiAkbpi41xb+C44x54YKnbk9+dtfs3pM4hECA==
 
 symbol-observable@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
This PR upgrades the svelte transformer from version 3.20.1 to 3.44.3.

This allows for newer Svelte language features to be parseable.

For example, the [`$$slots` object](https://github.com/sveltejs/svelte/blob/master/CHANGELOG.md#3250) was added in Svelte version 3.25. With v3.20, we encounter an "illegal variable name" error:

<img width="1110" alt="Screen Shot 2021-12-29 at 1 07 43 PM" src="https://user-images.githubusercontent.com/10718366/147703634-52186a8c-f3f3-4c6c-9cf7-4f6820464116.png">

The syntax is valid when using the latest version:

<img width="1167" alt="Screen Shot 2021-12-29 at 1 07 54 PM" src="https://user-images.githubusercontent.com/10718366/147703615-acec93b3-28e8-4a70-8483-5556603fd2b3.png">
