### PR TITLE
Improve ESLint v8 example rule 

### DIFF
--- a/website/src/parsers/js/transformers/eslint8/codeExample.txt
+++ b/website/src/parsers/js/transformers/eslint8/codeExample.txt
@@ -1,4 +1,10 @@
-export default function(context) {
+export const meta = {
+  type: 'problem',
+  hasSuggestions: true,
+  fixable: true,
+};
+
+export function create(context) {
   return {
     TemplateLiteral(node) {
       context.report({


### PR DESCRIPTION
Fixes the current error that appears on the site when you delete the `${i}` from the example:

> Fixable rules must set the `meta.fixable` property to "code" or "whitespace".
> Occurred while linting <input>:18
> Rule: "astExplorerRule"

With this change it will be easier to modify the example rule to make fixes and suggestions.