### PR TITLE
Upgrade svelte to 3.52

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -154,7 +154,7 @@
     "solidity-parser-diligence": "^0.4.18",
     "source-map": "^0.6.1",
     "sqlite-parser": "^1.0.0-rc3",
-    "svelte": "^3.46.2",
+    "svelte": "^3.52.0",
     "tenko": "^1.0.6",
     "tern": "^0.24.3",
     "traceur": "0.0.111",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -10920,10 +10920,10 @@ supports-color@^8.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-svelte@^3.46.2:
-  version "3.46.2"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.46.2.tgz#f0ffbffaea3a9a760edcbefc0902b41998a686ad"
-  integrity sha512-RXSAtYNefe01Sb1lXtZ2I+gzn3t/h/59hoaRNeRrm8IkMIu6BSiAkbpi41xb+C44x54YKnbk9+dtfs3pM4hECA==
+svelte@^3.52.0:
+  version "3.52.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.52.0.tgz#08259eff20904c63882b66a5d409a55e8c6743b8"
+  integrity sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ==
 
 symbol-observable@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Currently, the Svelte compiler is unable to recognize `svelte:element` tags or `@const` tags in `#if` blocks. This PR upgrades svelte to the latest minor version.

In the AST Explorer, the Svelte compiler is unable to parse the following code. It works in the [Svelte REPL](https://svelte.dev/repl/dd9b63a367cc46139ab770341d45f2d5?version=3.49.0) when using the latest minor version.

```svelte
<!-- 3.48.0 -->
{#if true}
  {@const a = 44}
    {a}
{/if}

<!-- 3.47.0 -->
<svelte:element this="h6">
  h6 tag
</svelte:element>

```

![astexplorer – svelte@3.46.2](https://user-images.githubusercontent.com/10718366/183455169-16c3d70a-f4cd-4440-85be-04c8fae747cc.png)
