### PR TITLE
Add Svelte as a top-level category

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The AST explorer provides following code parsers:
   - [solidity-parser-antlr][]
 - SQL:
   - [sqlite-parser][]
+- Svelte:
+  - [svelte][]
 - [WebIDL][]
 - YAML:
   - [yaml][]

--- a/website/src/parsers/svelte/codeExample.txt
+++ b/website/src/parsers/svelte/codeExample.txt
@@ -1,0 +1,5 @@
+<script>
+  let name = 'world';
+</script>
+
+<h1>Hello {name}!</h1>

--- a/website/src/parsers/svelte/index.js
+++ b/website/src/parsers/svelte/index.js
@@ -1,0 +1,6 @@
+import 'codemirror/mode/htmlmixed/htmlmixed';
+
+export const id = 'svelte';
+export const displayName = 'Svelte';
+export const mimeTypes = ['text/html'];
+export const fileExtension = 'svelte';

--- a/website/src/parsers/svelte/svelte-parser.js
+++ b/website/src/parsers/svelte/svelte-parser.js
@@ -1,0 +1,1 @@
+export { default } from '../html/svelte';


### PR DESCRIPTION
Currently, Svelte is a parser under the HTML category. Although Svelte markup is a superset of HTML, Svelte can be considered its own language[^1].

This PR adds Svelte as its own top-level category, which also makes it easier to locate.

[^1]: [what-is-svelte.md](https://gist.github.com/Rich-Harris/0f910048478c2a6505d1c32185b61934)

![ast-explorer-svelte](https://user-images.githubusercontent.com/10718366/183723228-1152d0ea-6abf-4053-ba7f-b248410dd71c.png)
