### PR TITLE
Add new SQL parser: sql-parser-cst

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -153,6 +153,7 @@
     "solidity-parser-antlr": "^0.4.0",
     "solidity-parser-diligence": "^0.4.18",
     "source-map": "^0.6.1",
+    "sql-parser-cst": "^0.5.1",
     "sqlite-parser": "^1.0.0-rc3",
     "svelte": "^3.46.2",
     "tenko": "^1.0.6",

--- a/website/src/parsers/sql/sql-parser-cst.js
+++ b/website/src/parsers/sql/sql-parser-cst.js
@@ -16,12 +16,8 @@ export default {
     require(['sql-parser-cst'], callback);
   },
 
-  parse(parser, code) {
-    return parser.parse(code, {
-      dialect: 'sqlite',
-      preserveComments: true,
-      includeRange: true,
-    });
+  parse(parser, code, options) {
+    return parser.parse(code, options);
   },
 
   getNodeName(node) {
@@ -30,5 +26,25 @@ export default {
 
   nodeToRange(node) {
     return node.range;
+  },
+
+  getDefaultOptions() {
+    return {
+      dialect: 'sqlite',
+      preserveComments: true,
+      includeRange: true,
+    };
+  },
+
+  _getSettingsConfiguration() {
+    return {
+      fields: [
+        ['dialect', ['sqlite', 'mysql']],
+        'preserveComments',
+        'preserveNewlines',
+        'preserveSpaces',
+        'includeRange',
+      ],
+    };
   },
 };

--- a/website/src/parsers/sql/sql-parser-cst.js
+++ b/website/src/parsers/sql/sql-parser-cst.js
@@ -1,0 +1,34 @@
+import defaultParserInterface from '../utils/defaultParserInterface';
+import pkg from 'sql-parser-cst/package.json';
+
+const ID = 'sql-parser-cst';
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: ID,
+  version: pkg.version,
+  homepage: pkg.homepage || 'https://github.com/nene/sql-parser-cst',
+  locationProps: new Set(['range']),
+
+  loadParser(callback) {
+    require(['sql-parser-cst'], callback);
+  },
+
+  parse(parser, code) {
+    return parser.parse(code, {
+      dialect: 'sqlite',
+      preserveComments: true,
+      includeRange: true,
+    });
+  },
+
+  getNodeName(node) {
+    return node.type;
+  },
+
+  nodeToRange(node) {
+    return node.range;
+  },
+};

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -10619,6 +10619,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+sql-parser-cst@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/sql-parser-cst/-/sql-parser-cst-0.5.1.tgz#8091152c29f8d04567adf391100ce386509f9f20"
+  integrity sha512-JtLWpkwOG/ILxkbkkf3pA5pNXZd8gm7eyjnXFyNgEceiQV0ut5WXDXqZNnSChugnoqPHV2XrSPFG/uGFn2ywiA==
+
 sqlite-parser@^1.0.0-rc3:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sqlite-parser/-/sqlite-parser-1.0.1.tgz#110183f2682f04ac6c7d8ad09c44446ef976d5ec"


### PR DESCRIPTION
Here's a pull request to support new parser for SQL.

As it supports parsing multiple SQL dialects (though for now only two) I've included a config option to switch between the dialects, plus a few more settings.

PS. This is an awesome project. I've been happily using this for years. Big thanks for creating and maintaining it 👍 