### PR TITLE
Add a category and the corresponding template parser for Liquid 

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -112,6 +112,7 @@
     "jscodeshift": "^0.11.0",
     "json-stringify-safe": "^5.0.1",
     "json-to-ast": "^2.1.0",
+    "liquidjs": "^10.0.0",
     "lodash.isequal": "^4.5.0",
     "luaparse": "^0.3.0",
     "lucene": "^2.1.1",

--- a/website/src/parsers/liquid/codeExample.txt
+++ b/website/src/parsers/liquid/codeExample.txt
@@ -1,0 +1,6 @@
+<h2>Introduction to Liquid</h2>
+<p>
+{% if username %}
+  {{ username | append: ", welcome to Liquid!" | capitalize }}
+{% endif %}
+</p>

--- a/website/src/parsers/liquid/index.js
+++ b/website/src/parsers/liquid/index.js
@@ -1,0 +1,7 @@
+import 'codemirror/mode/htmlmixed/htmlmixed';
+
+export const id = 'liquid';
+export const displayName = 'Liquid';
+export const mimeTypes = ['text/html'];
+export const fileExtension = 'liquid';
+export const editorMode = 'htmlmixed';

--- a/website/src/parsers/liquid/liquidjs-parser.js
+++ b/website/src/parsers/liquid/liquidjs-parser.js
@@ -1,0 +1,69 @@
+import defaultParserInterface from '../utils/defaultParserInterface';
+import pkg from 'liquidjs/package.json';
+
+const ID = 'liquidjs';
+
+const TokenNames = {
+  1: 'Number',
+  2: 'Literal',
+  4: 'Tag',
+  8: 'Output',
+  16: 'HTML',
+  32: 'Filter',
+  64: 'Hash',
+  128: 'PropertyAccess',
+  256: 'Word',
+  512: 'Range',
+  1024: 'Quoted',
+  2048: 'Operator',
+};
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: ID,
+  version: pkg.version,
+  homepage: pkg.homepage,
+  locationProps: new Set(['begin', 'end']),
+  typeProps: new Set(['kind']),
+
+  loadParser(callback) {
+    require(['liquidjs'], (module) => callback(new module.Liquid()));
+  },
+
+  parse(parser, code) {
+    return parser.parse(code);
+  },
+
+  opensByDefault(node, key) {
+    return key === 'token';
+  },
+
+  nodeToRange(node) {
+    if (typeof node.kind === 'number') {
+      return [node.begin, node.end];
+    }
+    if (node.token && typeof node.token.kind === 'number') {
+      return [node.token.begin, node.token.end];
+    }
+  },
+
+  getNodeName(node) {
+    if (node.kind) {
+      return `${TokenNames[node.kind]}Token`
+    }
+    if (node.token) {
+      const tokenKind = TokenNames[node.token.kind];
+      if (tokenKind === 'Tag') {
+        return `Tag(${node.name})`
+      }
+      return tokenKind
+    }
+  },
+
+  getDefaultOptions() {
+    return {};
+  },
+  _ignoredProperties: new Set(['liquid', 'impl', 'file', 'kind', 'input', 'trimLeft', 'trimRight']),
+};

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -7175,6 +7175,11 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+liquidjs@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/liquidjs/-/liquidjs-10.0.0.tgz#282579e9f90f4bfd92ef7d09ad4f5aac3ec9fd61"
+  integrity sha512-uY3fKqBSRmnat0wB5qWk0W5N5iT78OUhuIXNRiMfhYQ3p35al9mEWKQ68/Z+WD54V2upaxEM8nHaZ6o1B8WCMA==
+
 load-json-file@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"


### PR DESCRIPTION
Hi @fkling , thank you for this extremely useful repo, this is my second PR.

This PR added an AST viewer for Liquid language. [Liquid](https://shopify.github.io/liquid/) is defined by Shopify and used by Jekyll and thus Github Pages. There's [a JavaScript implementation](https://liquidjs.com/) for it and its parser is included in this PR.