### PR TITLE
Upgrade sql-parser-cst from 0.5.1 to 0.8.1

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -153,7 +153,7 @@
     "solidity-parser-antlr": "^0.4.0",
     "solidity-parser-diligence": "^0.4.18",
     "source-map": "^0.6.1",
-    "sql-parser-cst": "^0.5.1",
+    "sql-parser-cst": "^0.8.1",
     "sqlite-parser": "^1.0.0-rc3",
     "svelte": "^3.52.0",
     "tenko": "^1.0.6",

--- a/website/src/parsers/sql/sql-parser-cst.js
+++ b/website/src/parsers/sql/sql-parser-cst.js
@@ -39,7 +39,7 @@ export default {
   _getSettingsConfiguration() {
     return {
       fields: [
-        ['dialect', ['sqlite', 'mysql']],
+        ['dialect', ['sqlite', 'mysql', 'bigquery']],
         'preserveComments',
         'preserveNewlines',
         'preserveSpaces',

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -10606,10 +10606,10 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sql-parser-cst@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/sql-parser-cst/-/sql-parser-cst-0.5.1.tgz#8091152c29f8d04567adf391100ce386509f9f20"
-  integrity sha512-JtLWpkwOG/ILxkbkkf3pA5pNXZd8gm7eyjnXFyNgEceiQV0ut5WXDXqZNnSChugnoqPHV2XrSPFG/uGFn2ywiA==
+sql-parser-cst@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/sql-parser-cst/-/sql-parser-cst-0.8.1.tgz#4b416f3e3ebf5608affe0ae9b93e3d0f6bd7c935"
+  integrity sha512-FSQOHsA+l/Aq+ZwL1gsQNZ2gFar25hXwuWHw4XLTzc7Nh/rS/EloeN9j8k5sEwJAeRMhsL2DyYobUvD06FEtKg==
 
 sqlite-parser@^1.0.0-rc3:
   version "1.0.1"


### PR DESCRIPTION
This version brings BigQuery support, so I also added the new language to the dropdown in settings. Plus the syntax tree produced by sql-parser-cst has had some major changes between 0.5 and 0.8 versions.

Normally I would avoid throwing PR-s to AstExplorer for every little upgrade, but this one completely changes how table and column names are represented, making the syntax tree in 0.5 largely incompatible with the one in 0.8.