### PR TITLE
chore(deps): update hermes-parser to 0.18.0

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -103,7 +103,7 @@
     "graphql": "^15.0.0",
     "halting-problem": "^1.0.2",
     "handlebars": "^4.7.6",
-    "hermes-parser": "^0.4.7",
+    "hermes-parser": "^0.18.0",
     "htmlparser2": "^5.0.1",
     "hyntax": "^1.1.5",
     "intl-messageformat-parser": "^6.1.0",

--- a/website/src/parsers/js/hermes/hermes-worker.js
+++ b/website/src/parsers/js/hermes/hermes-worker.js
@@ -3,7 +3,7 @@
 // A Web Worker that wraps methods from the hermes-parser package behind a
 // minimal request/response protocol.
 
-import hermesParser from 'hermes-parser';
+import * as hermesParser from 'hermes-parser';
 
 const handlers = {
   parse(code, options) {

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6221,10 +6221,17 @@ he@1.2.x, he@^1.1.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hermes-parser@^0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.4.7.tgz#410f5129d57183784d205a0538e6fbdcf614c9ea"
-  integrity sha512-jc+zCtXbtwTiXoMAoXOHepxAaGVFIp89wwE9qcdwnMd/uGVEtPoY8FaFSsx0ThPvyKirdR2EsIIDVrpbSXz1Ag==
+hermes-estree@0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.18.0.tgz#6c202d8c78ddefadf3eb595a584dfa55b51a0508"
+  integrity sha512-WaIudIVKo5QWFqz1ta53HqSDuVxYST/MUuP9X7dqUpbHse3E2gzJq/7hEtgx84hh2XSNWN1AhYho3ThOA85uCA==
+
+hermes-parser@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.18.0.tgz#dd9878f70e9ca2570e7626181ae0465115f7f78d"
+  integrity sha512-DIIM6vsy30BU5hNkOXh6MR2r4ZAxVhbfyTnmfo/rqUf3KySlNWn9fWiOcpuGAdDN2o5sdPCpu6cep3a23d1Klw==
+  dependencies:
+    hermes-estree "0.18.0"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
I've updated the hermes-parser dependency to 0.18.0.

Changelog can be found here: https://github.com/facebook/hermes/blob/main/tools/hermes-parser/js/CHANGELOG.md

I've tested this locally and verified there are no errors and the latest features of hermes-parser are working as expected. 

<img width="980" alt="Screenshot 2023-12-01 at 3 22 56 PM" src="https://github.com/fkling/astexplorer/assets/3639670/4089e3f0-d4b2-42dc-8683-ee4d3022b890">

