### PR TITLE
feat: Update codemirror version

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -79,7 +79,7 @@
     "babylon6": "npm:babylon@^6",
     "babylon7": "npm:@babel/parser@^7",
     "cherow": "^1.6.8",
-    "codemirror": "^5.22.0",
+    "codemirror": "^5.65.16",
     "codemirror-graphql": "^0.11.6",
     "css": "^2.2.1",
     "css-tree": "^2.0.0",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3780,10 +3780,10 @@ codemirror-graphql@^0.11.6:
     graphql-language-service-interface "^2.3.3"
     graphql-language-service-parser "^1.5.2"
 
-codemirror@^5.22.0:
-  version "5.52.2"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.52.2.tgz#c29e1f7179f85eb0dd17c0586fa810e4838ff584"
-  integrity sha512-WCGCixNUck2HGvY8/ZNI1jYfxPG5cRHv0VjmWuNzbtCLz8qYA5d+je4QhSSCtCaagyeOwMi/HmmPTjBgiTm2lQ==
+codemirror@^5.65.16:
+  version "5.65.16"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.65.16.tgz#efc0661be6bf4988a6a1c2fe6893294638cdb334"
+  integrity sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg==
 
 collapse-white-space@^1.0.0, collapse-white-space@^1.0.2:
   version "1.0.6"


### PR DESCRIPTION
Pull request to fix the issue: CodeMirror editor displays error on JavaScript class private fields

Fixes #702

Updated codemirror version to the lastest _^5_ in _package.json_ and _yarn.lock_.