### PR TITLE
add solidity-parser/parser (latest maintained parser of solidity)

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,7 @@
   "author": "Felix Kling",
   "devDependencies": {
     "@babel/core": "^7.16.0",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
     "@babel/plugin-transform-runtime": "^7.16.0",
     "@babel/preset-env": "^7.16.0",
     "@babel/preset-react": "^7.16.0",
@@ -53,6 +54,7 @@
     "@glimmer/syntax": "^0.83.1",
     "@humanwhocodes/momoa": "^2.0.0",
     "@mdx-js/mdx": "^1.5.8",
+    "@solidity-parser/parser": "^0.20.0",
     "@swc/wasm-web": "^1.2.146",
     "@typescript-eslint/parser": "^5.59.7",
     "@vue/compiler-dom": "^3.0.0-rc.10",

--- a/website/src/parsers/solididy/solidity-parser-parser.js
+++ b/website/src/parsers/solididy/solidity-parser-parser.js
@@ -1,0 +1,49 @@
+import pkg from '@solidity-parser/parser/package.json';
+import defaultParserInterface from '../utils/defaultParserInterface';
+
+const ID = 'solidity-parser-parser';
+
+export default {
+  ...defaultParserInterface,
+
+  id: ID,
+  displayName: ID,
+  version: pkg.version,
+  homepage: pkg.homepage || 'https://github.com/solidity-parser/parser',
+
+  loadParser(callback) {
+    require(['@solidity-parser/parser'], callback);
+  },
+
+  parse(parser, code, options) {
+    return parser.parse(code, options);
+  },
+
+  opensByDefault(node, key) {
+    return node.type === 'SourceUnit' ||
+      node.type === 'ContractDefinition' ||
+      key === 'children' ||
+      key === 'subNodes' ||
+      key === 'body'
+  },
+
+  getDefaultOptions() {
+    return {
+      range: true,
+      loc: false,
+      tolerant: false,
+    };
+  },
+
+  _getSettingsConfiguration() {
+    return {
+      fields: [
+        'range',
+        'loc',
+        'tolerant',
+      ],
+    };
+  },
+
+};
+

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -216,6 +216,7 @@ module.exports = Object.assign({
           path.join(__dirname, 'node_modules', 'tslint'),
           path.join(__dirname, 'node_modules', 'tslib'),
           path.join(__dirname, 'node_modules', 'svelte'),
+          path.join(__dirname, 'node_modules', '@solidity-parser/parser'),
           path.join(__dirname, 'src'),
         ],
         loader: 'babel-loader',
@@ -235,6 +236,7 @@ module.exports = Object.assign({
           ],
           plugins: [
             require.resolve('@babel/plugin-transform-runtime'),
+            require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'),
           ],
         },
       },

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1423,6 +1423,11 @@
   resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
   integrity sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==
 
+"@solidity-parser/parser@^0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.20.0.tgz#e221b2f29a8c2fbeab56fea6d135e28b569b9ba9"
+  integrity sha512-eYOX1xI9ssc3AIZtKPdE2chG1OT9S74O16b8GhWGab63NS5g4jyQgW5OiwUiX9ACL0FR24rVDaHo+BB0bRSHhQ==
+
 "@swc/wasm-web@^1.2.146":
   version "1.2.146"
   resolved "https://registry.yarnpkg.com/@swc/wasm-web/-/wasm-web-1.2.146.tgz#f8c0bc7204b782d94beb6f99be2c776cd19455aa"


### PR DESCRIPTION
all parsers already provide for solidity are outdated and not maintained anymore. i have added support for [solidity-parser/parser](https://github.com/solidity-parser/parser) which is a fork thats maintained and has much more usage in the community by libraries like solhint, sol2um, etc.